### PR TITLE
feat: add qbittorrent download provider support

### DIFF
--- a/.config/download_provider.cfg
+++ b/.config/download_provider.cfg
@@ -11,5 +11,14 @@
         "token_js_path": "/root/.config/dependencies/xunlei_download_provider/get_token.js",
         "http_endpoint": "http://192.168.1.7:2345",
         "device_id": "5c78ea560a34ed4b4fbe6686da1172b4"
+    },
+    "qbittorrent_download_provider": {
+        "enable": false,
+        "download_base_path": "/downloads/",
+        "http_endpoint_host": "http://127.0.0.1",
+        "http_endpoint_port": 8080,
+        "username": "admin",
+        "password": "adminadmin",
+        "verify_webui_certificate": false
     }
 }

--- a/.pylintrc
+++ b/.pylintrc
@@ -9,6 +9,7 @@ disable=
     C0201, # consider-iterating-dictionary
     I1101, # Module 'libtorrent' has no 'torrent_info' member
     W0719, # Raising too general exception
+    R0902, # Too many instance attributes
 
 [SIMILARITIES]
 # Minimum lines number of a similarity.

--- a/hack/install_qbittorrent.sh
+++ b/hack/install_qbittorrent.sh
@@ -1,0 +1,49 @@
+# Ref: https://github.com/SuperNG6/Docker-qBittorrent-Enhanced-Edition
+#!/bin/sh
+
+set -e
+
+# 1.Echo logo
+cat << "EOF"
+ _          _                     _     _
+| | ___   _| |__   ___  ___ _ __ (_) __| | ___ _ __
+| |/ / | | | '_ \ / _ \/ __| '_ \| |/ _` |/ _ \ '__|
+|   <| |_| | |_) |  __/\__ \ |_) | | (_| |  __/ |
+|_|\_\\__,_|_.__/ \___||___/ .__/|_|\__,_|\___|_|
+                           |_|  
+EOF
+echo "[INFO] Start to deploy qbittorrent..."
+
+# 2.Check env
+ret=`docker version`
+if [[ $? != 0 ]]; then
+    echo "[ERROR] Please install docker"
+    exit 1
+fi
+
+# 3.Create necessary directory
+mkdir -p ${HOME}/kubespider/nas/
+mkdir -p ${HOME}/kubespider/qbittorrent/
+
+# 4.Set registry
+source hack/util.sh
+util::set_registry_for_image
+
+# 5.Install qbittorrent
+docker run -itd  \
+    --name=qbittorrentee  \
+    -e WEBUIPORT=8080  \
+    -e PUID=1026 \
+    -e PGID=100 \
+    -e TZ=Asia/Shanghai \
+    -p 6881:6881  \
+    -p 6881:6881/udp  \
+    -p 8080:8080  \
+    -v ${HOME}/kubespider/qbittorrent/config:/config  \
+    -v ${HOME}/kubespider/qbittorrent/downloads:/downloads  \
+    --restart unless-stopped  \
+    superng6/qbittorrentee:latest
+
+# 5.Notice
+echo "[INFO] Deploy Qbittorrent Enhanced Edition success, enjoy your time..."
+echo "[INFO] Qbittorrent web address is: http://<server_ip>:8080"

--- a/hack/install_qbittorrent.sh
+++ b/hack/install_qbittorrent.sh
@@ -22,7 +22,6 @@ if [[ $? != 0 ]]; then
 fi
 
 # 3.Create necessary directory
-mkdir -p ${HOME}/kubespider/nas/
 mkdir -p ${HOME}/kubespider/qbittorrent/
 
 # 4.Set registry

--- a/hack/install_qbittorrent.sh
+++ b/hack/install_qbittorrent.sh
@@ -35,11 +35,9 @@ docker run -itd  \
     -e PUID=1026 \
     -e PGID=100 \
     -e TZ=Asia/Shanghai \
-    -p 6881:6881  \
-    -p 6881:6881/udp  \
-    -p 8080:8080  \
-    -v ${HOME}/kubespider/qbittorrent/config:/config  \
-    -v ${HOME}/kubespider/qbittorrent/downloads:/downloads  \
+    --network=host \
+    -v ${HOME}/kubespider/qbittorrent/:/config  \
+    -v ${HOME}/kubespider/nas/:/downloads  \
     --restart unless-stopped  \
     superng6/qbittorrentee:latest
 

--- a/kubespider/core/kubespider_global.py
+++ b/kubespider/core/kubespider_global.py
@@ -3,6 +3,7 @@ import source_provider.btbtt12_disposable_source_provider.provider as btbtt12_di
 import source_provider.meijutt_source_provider.provider as meijutt_source_provider
 import download_provider.aria2_download_provider.provider as aria2_download_provider
 import download_provider.xunlei_download_provider.provider as xunlei_download_provider
+import download_provider.qbittorrent_download_provider.provider as qbittorrent_download_provider
 
 
 source_providers = [
@@ -14,6 +15,7 @@ source_providers = [
 download_providers = [
     aria2_download_provider.Aria2DownloadProvider(),
     xunlei_download_provider.XunleiDownloadProvider(),
+    qbittorrent_download_provider.QbittorrentDownloadProvider(),
 ]
 
 enabled_source_provider = []

--- a/kubespider/download_provider/qbittorrent_download_provider/provider.py
+++ b/kubespider/download_provider/qbittorrent_download_provider/provider.py
@@ -5,7 +5,9 @@ import qbittorrentapi
 
 from download_provider import provider
 
-class QbittorrentDownloadProvider(provider.DownloadProvider):
+class QbittorrentDownloadProvider(
+        provider.DownloadProvider # pylint length
+    ):
     def __init__(self) -> None:
         self.provider_name = 'qbittorrent_download_provider'
         self.http_endpoint_host = ''
@@ -29,9 +31,11 @@ class QbittorrentDownloadProvider(provider.DownloadProvider):
         try:
             ret = self.client.torrents_add(torrent_files=torrent_file_path, save_path=download_path)
             logging.info('Create download task results:%s', ret)
+            return None
         except Exception as err:
             logging.warning('Please ensure your qbittorrent server or your config are ok:%s', err)
             return err
+        return None
 
     def send_magnet_task(self, url, path):
         logging.info('Start magent download:%s, path:%s', url, path)
@@ -39,9 +43,11 @@ class QbittorrentDownloadProvider(provider.DownloadProvider):
         try:
             ret = self.client.torrents_add(urls=url, save_path=download_path)
             logging.info('Create download task results:%s', ret)
+            return None
         except Exception as err:
             logging.warning('Please ensure your qbittorrent server or your config are ok:%s', err)
             return err
+        return None
 
     def send_general_task(self, url, path):
         logging.warning('qbittorrent not support generatl task download! Please use aria2 or else download provider')
@@ -65,6 +71,8 @@ class QbittorrentDownloadProvider(provider.DownloadProvider):
         )
         try:
             self.client.auth_log_in()
+            return None
         except qbittorrentapi.LoginFailed as err:
             logging.warning('Auth into qbittorrent error:%s', err)
             return err
+        return None

--- a/kubespider/download_provider/qbittorrent_download_provider/provider.py
+++ b/kubespider/download_provider/qbittorrent_download_provider/provider.py
@@ -1,0 +1,70 @@
+import logging
+import os
+
+import qbittorrentapi
+
+from download_provider import provider
+
+class QbittorrentDownloadProvider(provider.DownloadProvider):
+    def __init__(self) -> None:
+        self.provider_name = 'qbittorrent_download_provider'
+        self.http_endpoint_host = ''
+        self.http_endpoint_port = 0
+        self.client = None
+        self.username = ''
+        self.password = ''
+        self.download_base_path = ''
+        self.verify_webui_certificate = False
+
+    def get_provider_name(self):
+        return self.provider_name
+
+    def provider_enabled(self):
+        cfg = provider.load_download_provider_config(self.provider_name)
+        return cfg['enable']
+
+    def send_torrent_task(self, torrent_file_path, download_path):
+        download_path = os.path.join(self.download_base_path, download_path)
+        logging.info('Start torrent download:%s, path:%s', torrent_file_path, download_path)
+        try:
+            ret = self.client.torrents_add(torrent_files=torrent_file_path, save_path=download_path)
+            logging.info('Create download task results:%s', ret)
+        except Exception as err:
+            logging.warning('Please ensure your qbittorrent server or your config are ok:%s', err)
+            return err
+
+    def send_magnet_task(self, url, path):
+        logging.info('Start magent download:%s, path:%s', url, path)
+        download_path = os.path.join(self.download_base_path, path)
+        try:
+            ret = self.client.torrents_add(urls=url, save_path=download_path)
+            logging.info('Create download task results:%s', ret)
+        except Exception as err:
+            logging.warning('Please ensure your qbittorrent server or your config are ok:%s', err)
+            return err
+
+    def send_general_task(self, url, path):
+        logging.warning('qbittorrent not support generatl task download! Please use aria2 or else download provider')
+        return TypeError('qbittorrent not support generate task download')
+
+
+    def load_config(self):
+        cfg = provider.load_download_provider_config(self.provider_name)
+        self.http_endpoint_host = cfg['http_endpoint_host']
+        self.http_endpoint_port = cfg['http_endpoint_port']
+        self.download_base_path = cfg['download_base_path']
+        self.username = cfg['username']
+        self.password = cfg['password']
+        self.verify_webui_certificate = cfg['verify_webui_certificate']
+        self.client = qbittorrentapi.Client(
+            self.http_endpoint_host,
+            self.http_endpoint_port,
+            self.username,
+            self.password,
+            VERIFY_WEBUI_CERTIFICATE=self.verify_webui_certificate,
+        )
+        try:
+            self.client.auth_log_in()
+        except qbittorrentapi.LoginFailed as err:
+            logging.warning('Auth into qbittorrent error:%s', err)
+            return err

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests==2.28.1
 setuptools==65.5.1
 pyexecjs==1.5.1
 libtorrent==2.0.7
+qbittorrent-api


### PR DESCRIPTION
Fix #56 

## Add qbittorrent support

- Add qbittorrent download provider
- Add qbittorrent config into download_provider.cfg
- Add a docker based qbittorrent script for newer

**Due to the fact that qbittorrent only supports torrent or magnet link, this provider doesn't support general link download**