### PR TITLE
Feature/qb param

### DIFF
--- a/docs/zh/user_guide/qbittorrent_download_provider/README.md
+++ b/docs/zh/user_guide/qbittorrent_download_provider/README.md
@@ -74,7 +74,11 @@ qBittorrent对应的配置文件如下
         "username": "admin",
         "password": "adminadmin",
         "verify_webui_certificate": false,
-        "priority": 1
+        "priority": 1,
+        "tags": [
+            "kubespider"
+        ],
+        "category": "kubespider"
     }
 }
 ```
@@ -87,6 +91,8 @@ qBittorrent对应的配置文件如下
 * `password`: 登录WebAPI的密码，与WebAPI设置中保持一致。
 * `verify_webui_certificate`: 是否启用WebAPI的证书认证，目前务必设置为false。
 * `priority`: 下载提供器优先级，数字越小，优先级越高，下载资源时按优先级尝试，无法下载或下载失败时切换下载器。
+* `tags`: 触发下载时使用的tag，可用于资源分类，不需要时可留空或不设置。
+* `category`: 触发下载时使用的category，可用于资源分类，不需要时可留空或不设置。
 
 ### 4.测试下载
 配置好后，运行如下命令：

--- a/kubespider/core/kubespider.py
+++ b/kubespider/core/kubespider.py
@@ -20,7 +20,7 @@ def run():
                 logging.info('Source Provider:%s enabled...', provider_name)
                 kubespider_global.enabled_source_provider.append(provider)
         except KeyError:
-            logging.warn('Source Provider:%s not exists, treat as disabled', provider_name)
+            logging.warning('Source Provider:%s not exists, treat as disabled', provider_name)
 
     for provider in kubespider_global.download_providers:
         provider_name = provider.get_provider_name()
@@ -29,7 +29,7 @@ def run():
                 logging.info('Download Provider:%s enabled...', provider_name)
                 kubespider_global.enabled_download_provider.append(provider)
         except KeyError:
-            logging.warn('Download Provider:%s not exists, treat as disabled', provider_name)
+            logging.warning('Download Provider:%s not exists, treat as disabled', provider_name)
     kubespider_global.enabled_download_provider.sort(key=sort_download_provider)
 
     download_trigger.kubespider_downloader = \

--- a/kubespider/core/kubespider.py
+++ b/kubespider/core/kubespider.py
@@ -15,15 +15,21 @@ def run():
 
     for provider in kubespider_global.source_providers:
         provider_name = provider.get_provider_name()
-        if provider.provider_enabled():
-            logging.info('Source Provider:%s enabled...', provider_name)
-            kubespider_global.enabled_source_provider.append(provider)
+        try:
+            if provider.provider_enabled():
+                logging.info('Source Provider:%s enabled...', provider_name)
+                kubespider_global.enabled_source_provider.append(provider)
+        except KeyError:
+            logging.warn('Source Provider:%s not exists, treat as disabled', provider_name)
 
     for provider in kubespider_global.download_providers:
         provider_name = provider.get_provider_name()
-        if provider.provider_enabled():
-            logging.info('Download Provider:%s enabled...', provider_name)
-            kubespider_global.enabled_download_provider.append(provider)
+        try:
+            if provider.provider_enabled():
+                logging.info('Download Provider:%s enabled...', provider_name)
+                kubespider_global.enabled_download_provider.append(provider)
+        except KeyError:
+            logging.warn('Download Provider:%s not exists, treat as disabled', provider_name)
     kubespider_global.enabled_download_provider.sort(key=sort_download_provider)
 
     download_trigger.kubespider_downloader = \

--- a/kubespider/download_provider/qbittorrent_download_provider/provider.py
+++ b/kubespider/download_provider/qbittorrent_download_provider/provider.py
@@ -20,6 +20,8 @@ class QbittorrentDownloadProvider(
         self.password = ''
         self.download_base_path = ''
         self.verify_webui_certificate = False
+        self.download_tags = ['']
+        self.download_category = ''
 
     def get_provider_name(self) -> str:
         return self.provider_name
@@ -62,7 +64,8 @@ class QbittorrentDownloadProvider(
         download_path = os.path.join(self.download_base_path, download_path)
         logging.info('Start torrent download:%s, path:%s', torrent_file_path, download_path)
         try:
-            ret = self.client.torrents_add(torrent_files=torrent_file_path, save_path=download_path)
+            logging.info('Create download task category:%s, tags:%s', self.download_category, self.download_tags)
+            ret = self.client.torrents_add(torrent_files=torrent_file_path, save_path=download_path, category=self.download_category, tags=self.download_tags)
             logging.info('Create download task results:%s', ret)
             return None
         except Exception as err:
@@ -74,7 +77,8 @@ class QbittorrentDownloadProvider(
         logging.info('Start magent download:%s, path:%s', url, path)
         download_path = os.path.join(self.download_base_path, path)
         try:
-            ret = self.client.torrents_add(urls=url, save_path=download_path)
+            logging.info('Create download task category:%s, tags:%s', self.download_category, self.download_tags)
+            ret = self.client.torrents_add(urls=url, save_path=download_path, category=self.download_category, tags=self.download_tags)
             logging.info('Create download task results:%s', ret)
             return None
         except Exception as err:
@@ -95,6 +99,8 @@ class QbittorrentDownloadProvider(
         self.username = cfg['username']
         self.password = cfg['password']
         self.verify_webui_certificate = cfg['verify_webui_certificate']
+        self.download_tags = cfg.get('tags')
+        self.download_category = cfg.get('category')
         self.client = qbittorrentapi.Client(
             self.http_endpoint_host,
             self.http_endpoint_port,


### PR DESCRIPTION
Fixes #

## Proposed Changes

* 允许`source_provider` `download_provider`不填写不需要的源
* `download_provider.qbittorrent_download_provider` 可配置 `tags`（数组）、`category`，便于下载资源的分类。

可部分解决 https://github.com/jwcesign/kubespider/issues/79 中kubespider复用现有qb容器时的资源分类管理问题。