### PR TITLE
support general rss provider

### DIFF
--- a/.config/source_provider.yaml
+++ b/.config/source_provider.yaml
@@ -9,6 +9,10 @@ btbtt12_disposable_source_provider:
 meijutt_source_provider:
   enable: true
   tv_links: []
+general_rss_source_provider:
+  enable: true
+  rss:
+    - {"id": "123123123", "rss_name": "深影译站", "rss_url": "http://192.168.124.10:1200/shinybbs", "provider_type": "disposable", "flag": "movie", "type": "电影", "provider_enabled": true, "decs": "decs", "exec_time": "8h", "check_time": "0h"}
 bilibili_source_provider:
   enable: true
 youtube_source_provider:

--- a/.config/state.yaml
+++ b/.config/state.yaml
@@ -1,2 +1,3 @@
----
+general_rss_source_provider: []
+general_rss_source_provider_disposable: []
 meijutt_source_provider: []

--- a/.github/ISSUE_TEMPLATE/ask-question.md
+++ b/.github/ISSUE_TEMPLATE/ask-question.md
@@ -1,0 +1,10 @@
+---
+name: Question
+about: Ask a question about Kubespider
+title: ''
+labels: kind/question
+assignees: ''
+
+---
+
+## Ask your question here:

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,18 @@
+---
+name: Feature Request
+about: Create a feature request for Kubespider
+title: ''
+labels: kind/feature
+assignees: ''
+
+---
+
+## Describe the background
+<!--
+Template: I always want to download videos from YouTube with Kubespider.
+-->
+
+## Describe the feature
+<!--
+Template: Implement youtube source provider, and it will parse the links and download it with you-get
+-->

--- a/kubespider/core/kubespider_global.py
+++ b/kubespider/core/kubespider_global.py
@@ -3,6 +3,7 @@ import source_provider.btbtt12_disposable_source_provider.provider as btbtt12_di
 import source_provider.meijutt_source_provider.provider as meijutt_source_provider
 import source_provider.bilibili_source_provider.provider as bilibili_source_provider
 import source_provider.youtube_source_provider.provider as youtube_source_provider
+import source_provider.general_rss_source_provider.provider as rss_source_provider
 
 import download_provider.aria2_download_provider.provider as aria2_download_provider
 import download_provider.xunlei_download_provider.provider as xunlei_download_provider
@@ -15,6 +16,7 @@ source_providers = [
     meijutt_source_provider.MeijuttSourceProvider(),
     bilibili_source_provider.BilibiliSourceProvider(),
     youtube_source_provider.YouTubeSourceProvider(),
+    rss_source_provider.GeneralRssSourceProvider(),
 ]
 
 download_providers = [

--- a/kubespider/source_provider/general_rss_source_provider/provider.py
+++ b/kubespider/source_provider/general_rss_source_provider/provider.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+
+"""
+@author: ijwstl
+@software: PyCharm
+@file: provider.py
+@time: 2023/4/12 19:45
+"""
+
+from source_provider import provider
+import feedparser
+import logging
+from api import types
+
+
+class GeneralRssSourceProvider(provider.SourceProvider):
+    def __init__(self, rss_config={}) -> None:
+        """
+        Description: init class of GeneralRssSourceProvider
+                    id: Unique identification of rss config
+                    provider_type: disposable or period
+                    rss_name: a name for the configuration, just like 美剧天堂
+                    rss_hub_link：the URL of rss hub resource
+                    webhook_enable: cannot be triggered by request
+                    enabled: True/False
+                    rss_tpye: this type is used to categorize the rss later in web
+                    file_type: this type is resource type
+                    link_type: this type is resource url type
+                    decs: this is description of rss
+                    exec_time: is used to exec timed tasks
+                    check_time: is used to exec timed tasks
+                    provider_name: provider_name
+
+        Args:
+            rss_config: config member of rss config, file is ./config/general_rss.json
+        """
+        self.id = rss_config.get("id")
+        self.provider_type = rss_config.get("provider_type")
+        self.rss_name = rss_config.get("rss_name")
+        self.rss_hub_link = rss_config.get("rss_url")
+        self.webhook_enable = False
+        self.enabled = rss_config.get("provider_enabled") if rss_config.get("provider_enabled") else True
+        self.rss_tpye = rss_config.get("type")
+        self.file_type = rss_config.get("flag") if rss_config.get("flag") in types.file_type_to_path.keys() else types.FILE_TYPE_COMMON
+        self.link_type = types.LINK_TYPE_MAGNET
+        self.decs = rss_config.get("decs")
+        self.exec_time = rss_config.get("exec_time")
+        self.check_time = rss_config.get("check_time")
+        self.provider_name = 'general_rss_source_provider'
+
+    def get_provider_name(self):
+        return self.provider_name
+
+    def provider_enabled(self):
+        return self.enabled
+
+    def get_provider_type(self):
+        return None
+
+    def get_file_type(self):
+        return self.file_type
+
+    def get_download_provider(self):
+        return None
+
+    def get_link_type(self):
+        return self.link_type
+
+    def get_download_path(self):
+        return self.download_path
+
+    def provider_enabled(self):
+        return self.provider_enabled
+
+    def is_webhook_enable(self):
+        return self.is_webhook_enable
+
+    def should_handle(self, dataSourceUrl):
+        pass
+
+    def get_rss_hub_link(self):
+        return self.rss_hub_link
+
+    def get_links(self, dataSourceUrl=""):
+        """
+        Description: get rss resource link for download
+
+        Args:
+            dataSourceUrl:
+
+        Returns:
+
+        """
+        links = []
+        rss_oschina = feedparser.parse(self.rss_hub_link)
+        if rss_oschina.get('entries'):
+            logging.warning("sorry, Not found source, please check the url of rsshub")
+
+        for entry in rss_oschina['entries']:
+            if not entry['links']:
+                logging.warning("{}, No links were found to download yet ".format(entry['title']))
+                continue
+            link_exist = False
+            for link_info in entry['links']:
+                if link_info["type"] == "application/x-bittorrent" or link_info["href"].startswith("magnet:?xt"):
+                    link_exist = True
+                    links.append({"link": link_info["href"], "file_type": self.file_type, "path": "/"}, )
+                    break
+            if not link_exist:
+                logging.warning("{}, No magnetic links were found to download yet".format(entry['title']))
+        return links
+
+    def update_config(self, reqPara):
+        pass
+
+    def load_config(self):
+        pass
+
+    def get_config(self):
+        return {
+            "id": self.id,
+            "rss_name": self.rss_name,
+            "rss_url": self.rss_hub_link,
+            "type": self.rss_tpye,
+            "provider_enabled": self.provider_enabled,
+            "decs": self.decs,
+            "provider_type": self.provider_type,
+            "exec_time": self.exec_time,
+            "check_time": self.check_time
+        }
+
+    def get_close_config(self):
+        return {
+            "id": self.id,
+            "rss_name": self.rss_name,
+            "rss_url": self.rss_hub_link,
+            "type": self.rss_tpye,
+            "provider_enabled": "close",
+            "decs": self.decs,
+            "provider_type": self.provider_type,
+            "exec_time": self.exec_time,
+            "check_time": self.check_time
+        }
+
+    def get_next_config(self):
+        return {
+            "id": self.id,
+            "rss_name": self.rss_name,
+            "rss_url": self.rss_hub_link,
+            "type": self.rss_tpye,
+            "provider_enabled": self.provider_enabled,
+            "decs": self.decs,
+            "provider_type": self.provider_type,
+            "exec_time": self.exec_time,
+            "check_time": self.check_time + 1
+        }


### PR DESCRIPTION
…t six kinds

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* support general rss provider, but custom refresh times are not currently supported
* for detailed configuration, see the example in the configuration file

**Release Note**
                    id: Unique identification of rss config
                    provider_type: disposable or period
                    rss_name: a name for the configuration, just like 美剧天堂
                    rss_hub_link：the URL of rss hub resource
                    webhook_enable: cannot be triggered by request
                    enabled: True/False
                    rss_tpye: this type is used to categorize the rss later in web
                    file_type: this type is resource type
                    link_type: this type is resource url type
                    decs: this is description of rss
                    exec_time: is used to exec timed tasks
                    check_time: is used to exec timed tasks
                    provider_name: provider_name

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```