### PR TITLE
支持同类型的多个下载器、订阅源，支持订阅源指定下载器

### DIFF
--- a/.config/download_provider.yaml
+++ b/.config/download_provider.yaml
@@ -1,17 +1,20 @@
 ---
-youget_download_provider:
+youget:
+  type: youget_download_provider
   enable: false
   http_endpoint_host: http://127.0.0.1
   http_endpoint_port: '3081'
   priority: 0
-aria2_download_provider:
+aria2:
+  type: aria2_download_provider
   enable: true
   download_base_path: "/downloads/"
   rpc_endpoint_host: http://127.0.0.1
   rpc_endpoint_port: '6800'
   secret: kubespider
   priority: 1
-qbittorrent_download_provider:
+qbittorrent:
+  type: qbittorrent_download_provider
   enable: false
   download_base_path: "/downloads/"
   http_endpoint_host: http://127.0.0.1
@@ -20,7 +23,10 @@ qbittorrent_download_provider:
   password: adminadmin
   verify_webui_certificate: false
   priority: 2
-xunlei_download_provider:
+  tags:
+    - kubespider
+xunlei:
+  type: xunlei_download_provider
   enable: false
   token_js_path: "/root/.config/dependencies/xunlei_download_provider/get_token.js"
   http_endpoint: http://127.0.0.1:2345

--- a/.config/source_provider.yaml
+++ b/.config/source_provider.yaml
@@ -5,6 +5,8 @@ mikanani_source_provider:
   # 将以下rss链接更换为自己的mikan订阅链接
   # 格式为 https://mikanani.me/RSS/MyBangumi?token=***mytoken***
   rss_link: https://mikanani.me/Home/Classic
+  downloader:
+    - qbittorrent
   download_param:
     tags:
       - mikanani

--- a/.config/source_provider.yaml
+++ b/.config/source_provider.yaml
@@ -5,8 +5,6 @@ mikanani_source_provider:
   # 将以下rss链接更换为自己的mikan订阅链接
   # 格式为 https://mikanani.me/RSS/MyBangumi?token=***mytoken***
   rss_link: https://mikanani.me/Home/Classic
-  downloader:
-    - qbittorrent
   download_param:
     tags:
       - mikanani

--- a/.config/source_provider.yaml
+++ b/.config/source_provider.yaml
@@ -1,15 +1,23 @@
 ---
 mikanani_source_provider:
+  type: mikanani_source_provider
   enable: false
   # 将以下rss链接更换为自己的mikan订阅链接
   # 格式为 https://mikanani.me/RSS/MyBangumi?token=***mytoken***
   rss_link: https://mikanani.me/Home/Classic
+  download_param:
+    tags:
+      - mikanani
 btbtt12_disposable_source_provider:
+  type: btbtt12_disposable_source_provider
   enable: true
 meijutt_source_provider:
+  type: meijutt_source_provider
   enable: true
   tv_links: []
 bilibili_source_provider:
+  type: bilibili_source_provider
   enable: true
 youtube_source_provider:
+  type: youtube_source_provider
   enable: true

--- a/.config/state.yaml
+++ b/.config/state.yaml
@@ -1,2 +1,0 @@
----
-meijutt_source_provider: []

--- a/docs/zh/user_guide/aria2_download_provider/README.md
+++ b/docs/zh/user_guide/aria2_download_provider/README.md
@@ -29,22 +29,24 @@ root@cesign [10:49:25 PM] [+41.0°C] [~/kubespider/.config]
 ![img](./images/aria2-config-for-chrome.jpg)
 
 ### 2.Kubespider对接配置（可选）
+
 aria2对应的配置文件如下：
-```json
-{
-    ...
-    "aria2_download_provider": {
-        "enable": true,
-        "download_base_path": "/downloads/",
-        "rpc_endpoint_host": "http://127.0.0.1",
-        "rpc_endpoint_port": "6800",
-        "secret": "kubespider",
-        "priority": 1
-    },
-    ...
-}
+
+```yaml
+aria2:
+  type: aria2_download_provider
+  enable: true
+  download_base_path: "/downloads/"
+  rpc_endpoint_host: http://127.0.0.1
+  rpc_endpoint_port: '6800'
+  secret: kubespider
+  priority: 1
 ```
+
 其中:
+
+* 名称，可自定义（不可重复），可以在 `source_provider.yaml` 中按名称指定下载器。
+* `type`: 表示此下载器的类型，需为 `aria2_download_provider`。
 * `enable`: 设置是否使用此provider，只能使用一个，后续开发优先级后可以多个一起使用。
 * `download_base_path`: 设置下载基础路径，后续文件都将保存在该目录中，务必设置在你所挂载的nas目录或其他目录。
 * `rpc_endpoint_host`: aria2 rpc地址。

--- a/docs/zh/user_guide/bilibili_source_provider/README.md
+++ b/docs/zh/user_guide/bilibili_source_provider/README.md
@@ -23,6 +23,8 @@ bilibili_source_provider:
 
 * `type`：订阅源类型，需为`bilibili_source_provider`。
 * `enable`：是否开启此provider，因为此provider无需口令等用户信息，所以默认开启。
+* `downloader`：指定使用的下载器，格式为数组，内容需要精确地跟 `downloader_provider.yaml` 中声明的名称一样；下载优先级将由数组顺序决定。
+* `download_param`：下载时传给下载器的额外参数，具体参数需要参考下载器定义。
 
 ## 测试
 设置好后，直接重启Kubespider即可。

--- a/docs/zh/user_guide/bilibili_source_provider/README.md
+++ b/docs/zh/user_guide/bilibili_source_provider/README.md
@@ -14,17 +14,15 @@
 
 ### 2.配置手册
 你可以通过`${HOME}/kubespider/.config/source_provider.cfg`配置，配置解释如下：
-```cfg
-{
-    ...
-    "bilibili_source_provider":{
-        "enable":true
-    }
-    ...
-}
+
+```yaml
+bilibili_source_provider:
+  type: bilibili_source_provider
+  enable: true
 ```
 
-`enable`：是否开启此provider，因为此provider无需口令等用户信息，所以默认开启。
+* `type`：订阅源类型，需为`bilibili_source_provider`。
+* `enable`：是否开启此provider，因为此provider无需口令等用户信息，所以默认开启。
 
 ## 测试
 设置好后，直接重启Kubespider即可。

--- a/docs/zh/user_guide/btbtt12_disposable_source_provider/README.md
+++ b/docs/zh/user_guide/btbtt12_disposable_source_provider/README.md
@@ -13,17 +13,14 @@ BT之家单版社区平台，最快提供最新最全高清电影、动漫、韩
 
 ### 2.配置手册
 你可以通过`${HOME}/kubespider/.config/source_provider.cfg`配置，配置解释如下：
-```cfg
-{
-    ...
-    "btbtt12_disposable_source_provider": {
-        "enable":true
-    },
-    ...
-}
+```yaml
+btbtt12_disposable_source_provider:
+  type: btbtt12_disposable_source_provider
+  enable: true
 ```
 
-`enable`：是否开启此provider，因为此provider无需口令等用户信息，所以默认开启。
+* `type`：订阅源类型，需为`btbtt12_disposable_source_provider`。
+* `enable`：是否开启此provider，因为此provider无需口令等用户信息，所以默认开启。
 
 ## 测试
 设置好后，直接重启Kubespider即可。

--- a/docs/zh/user_guide/btbtt12_disposable_source_provider/README.md
+++ b/docs/zh/user_guide/btbtt12_disposable_source_provider/README.md
@@ -21,6 +21,8 @@ btbtt12_disposable_source_provider:
 
 * `type`：订阅源类型，需为`btbtt12_disposable_source_provider`。
 * `enable`：是否开启此provider，因为此provider无需口令等用户信息，所以默认开启。
+* `downloader`：指定使用的下载器，格式为数组，内容需要精确地跟 `downloader_provider.yaml` 中声明的名称一样；下载优先级将由数组顺序决定。
+* `download_param`：下载时传给下载器的额外参数，具体参数需要参考下载器定义。
 
 ## 测试
 设置好后，直接重启Kubespider即可。

--- a/docs/zh/user_guide/meijutt_source_provider/README.md
+++ b/docs/zh/user_guide/meijutt_source_provider/README.md
@@ -13,19 +13,16 @@ meijutt有丰富的美剧内容，提供高质量下载资源。官方地址：[
 
 ### 2.配置手册
 你可以通过`${HOME}/kubespider/.config/source_provider.cfg`配置，配置解释如下：
-```cfg
-{
-    ...
-    "meijutt_source_provider": {
-        "enable": true,
-        "tv_links": []
-    },
-    ...
-}
+```yaml
+meijutt_source_provider:
+  type: meijutt_source_provider
+  enable: true
+  tv_links: []
 ```
 
-`enable`：是否开启此provider。  
-`tv_links`：tv剧地址，直接通过Kubespider chrome插件发送美剧地址URL即可，如最终效果图所示。
+* `type`：订阅源类型，需为`meijutt_source_provider`。
+* `enable`：是否开启此provider。  
+* `tv_links`：tv剧地址，直接通过Kubespider chrome插件发送美剧地址URL即可，如最终效果图所示。
 
 其中Server地址为 http://<server_ip>:3080
 

--- a/docs/zh/user_guide/meijutt_source_provider/README.md
+++ b/docs/zh/user_guide/meijutt_source_provider/README.md
@@ -23,6 +23,8 @@ meijutt_source_provider:
 * `type`：订阅源类型，需为`meijutt_source_provider`。
 * `enable`：是否开启此provider。  
 * `tv_links`：tv剧地址，直接通过Kubespider chrome插件发送美剧地址URL即可，如最终效果图所示。
+* `downloader`：指定使用的下载器，格式为数组，内容需要精确地跟 `downloader_provider.yaml` 中声明的名称一样；下载优先级将由数组顺序决定。
+* `download_param`：下载时传给下载器的额外参数，具体参数需要参考下载器定义。
 
 其中Server地址为 http://<server_ip>:3080
 

--- a/docs/zh/user_guide/mikanani_source_provider/README.md
+++ b/docs/zh/user_guide/mikanani_source_provider/README.md
@@ -8,26 +8,31 @@
 
 ## 配置手册
 你可以通过`${HOME}/kubespider/.config/source_provider.cfg`配置，配置解释如下：
-```cfg
-{
-   ...
-    "mikanani_source_provider": {
-        "enable": false,
-        "rss_link": "https://mikanani.me/RSS/MyBangumi?token=egIVi24Uxfg68bFDW5ehVgpHCadfZ1AULNYot%2b95mDo%3d"
-    },
-    ...
-}
+```yaml
+mikanani_source_provider:
+  type: mikanani_source_provider
+  enable: false
+  # 将以下rss链接更换为自己的mikan订阅链接
+  # 格式为 https://mikanani.me/RSS/MyBangumi?token=***mytoken***
+  rss_link: https://mikanani.me/Home/Classic
+  downloader:
+    - qbittorrent
+  download_param:
+    tags:
+      - mikanani
 ```
 
-`enable`：是否开启此provider。  
-`rss_link`：mikanani账号的rss链接，获取方法如下：  
-
-1. 去[mikanani](https://mikanani.me/)注册账号，开启高级订阅 
+* `type`：订阅源类型，需为`meijutt_source_provider`。
+* `enable`：是否开启此provider。  
+* `rss_link`：mikanani账号的rss链接，获取方法如下：  
+  1. 去[mikanani](https://mikanani.me/)注册账号，开启高级订阅 
    ![img](./images/mikanani_source_provider_cfg_1.jpg)
-2. 关注你喜欢的动漫
+  2. 关注你喜欢的动漫
    ![img](./images/mikanani_source_provider_cfg_2.jpg)
-3. 查看RSS链接，选择复制链接地址并设置为`rss_link`即可
+  3. 查看RSS链接，选择复制链接地址并设置为`rss_link`即可
    ![img](./images/mikanani_source_provider_cfg_3.jpg)
+* `downloader`：指定使用的下载器，格式为数组，内容需要精确地跟 `downloader_provider.yaml` 中声明的名称一样；下载优先级将由数组顺序决定。
+* `download_param`：下载时传给下载器的额外参数，具体参数需要参考下载器定义。
 
 ## 启用配置
 设置好后，直接重启Kubespider即可。

--- a/docs/zh/user_guide/qbittorrent_download_provider/README.md
+++ b/docs/zh/user_guide/qbittorrent_download_provider/README.md
@@ -96,6 +96,30 @@ qbittorrent:
 * `tags`: 触发下载时使用的tag，可用于资源分类，不需要时可留空或不设置。
 * `category`: 触发下载时使用的category，可用于资源分类，不需要时可留空或不设置。
 
+#### 3.1 来自订阅源的配置
+
+qBittorrent支持订阅源传递过来的下载参数：
+
+source_provider.yaml:
+
+```yaml
+---
+mikan_oshi:
+  enable: true
+  rss_link: https://mikanani.me/RSS/Bangumi?bangumiId=2995&subgroupid=534
+  type: mikanani_source_provider
+  downloader:
+    # 指定使用 qBittorrent进行下载
+    - qb
+  download_param:
+    tags:
+      - oshinoko
+      - mikan_tv
+    category: mikananime
+```
+
+在触发下载时，订阅源会将 `download_param` 内的参数传递过来，其值的含义参考上面的格式定义。
+
 ### 4.测试下载
 配置好后，运行如下命令：
 ```

--- a/docs/zh/user_guide/qbittorrent_download_provider/README.md
+++ b/docs/zh/user_guide/qbittorrent_download_provider/README.md
@@ -64,25 +64,27 @@ https://jsd.cdn.zzko.cn/gh/XIU2/TrackersListCollection/best.txt
 如果你对WebAPI进行了修改配置，请务必修改Kubespider的对接配置，如果没有修改则可以直接使用默认配置使用
 
 qBittorrent对应的配置文件如下
-```json
-{
-    "qbittorrent_download_provider": {
-        "enable": false,
-        "download_base_path": "/downloads/",
-        "http_endpoint_host": "http://127.0.0.1",
-        "http_endpoint_port": 8080,
-        "username": "admin",
-        "password": "adminadmin",
-        "verify_webui_certificate": false,
-        "priority": 1,
-        "tags": [
-            "kubespider"
-        ],
-        "category": "kubespider"
-    }
-}
+
+```yaml
+qbittorrent:
+  type: qbittorrent_download_provider
+  enable: false
+  download_base_path: "/downloads/"
+  http_endpoint_host: http://127.0.0.1
+  http_endpoint_port: 8080
+  username: admin
+  password: adminadmin
+  verify_webui_certificate: false
+  priority: 2
+  tags:
+    - kubespider
+  category: kubespider
 ```
+
 其中:
+
+* 名称，可自定义（不可重复），可以在 `source_provider.yaml` 中按名称指定下载器。
+* `type`: 表示此下载器的类型，需为 `qbittorrent_download_provider`。
 * `enable`: 设置是否使用此provider，只能使用一个，后续开发优先级后可以多个一起使用。
 * `download_base_path`: 设置下载基础路径，后续文件都将保存在该目录中，务必设置在你所挂载的nas目录或其他目录。
 * `http_endpoint_host`: qbittorrent服务所在服务器地址。

--- a/docs/zh/user_guide/thunder_install_config/README.md
+++ b/docs/zh/user_guide/thunder_install_config/README.md
@@ -80,20 +80,20 @@ curl http://<server_ip>:2345/webman/3rdparty/pan-xunlei-com/index.cgi/\#/home
 
 #### 6.设置download_provider文件
 配置文件如下：
-```json
-{
-    ...
-    "xunlei_download_provider": {
-        "enable": true,
-        "token_js_path": "/root/.config/dependencies/xunlei_download_provider/get_token.js",
-        "http_endpoint": "http://192.168.1.7:2345",
-        "device_id": "5c78ea560a34ed4b4fbe6686da1172b4",
-        "priority": 1
-    },
-    ...
-}
+```yaml
+xunlei:
+  type: xunlei_download_provider
+  enable: false
+  token_js_path: "/root/.config/dependencies/xunlei_download_provider/get_token.js"
+  http_endpoint: http://127.0.0.1:2345
+  device_id: 5c78ea560a34ed4b4fbe6686da1172b4
+  priority: 3
+
 ```
 其中：
+
+* 名称，可自定义（不可重复），可以在 `source_provider.yaml` 中按名称指定下载器。
+* `type`: 表示此下载器的类型，需为 `xunlei_download_provider`。
 * `enable`: 设置是否使用此provider，只能使用一个，后续开发优先级后可以多个一起使用。
 * `token_js_path`: 不用修改，如果你知道如何开发，可以修改。
 * `http_endpoint`: 服务地址。

--- a/docs/zh/user_guide/youget_download_provider/README.md
+++ b/docs/zh/user_guide/youget_download_provider/README.md
@@ -61,20 +61,22 @@ docker ps | grep youget
 
 ### 2.Kubespider对接配置（可选）
 #### 1.设置download_provider文件
+
 配置文件如下：
-```json
-{
-    ...
-    "youget_download_provider": {
-        "enable": false,
-        "http_endpoint_host": "http://127.0.0.1",
-        "http_endpoint_port": "3081",
-        "priority": 0
-    },
-    ...
-}
+
+```yaml
+youget:
+  type: youget_download_provider
+  enable: false
+  http_endpoint_host: http://127.0.0.1
+  http_endpoint_port: '3081'
+  priority: 0
 ```
+
 其中：
+
+* 名称，可自定义（不可重复），可以在 `source_provider.yaml` 中按名称指定下载器。
+* `type`: 表示此下载器的类型，需为 `youget_download_provider`。
 * `enable`: 设置是否使用此provider。
 * `http_endpoint_host`: you-get下载软件IP地址。
 * `http_endpoint`: you-get下载软件IP端口。

--- a/kubespider/core/download_trigger.py
+++ b/kubespider/core/download_trigger.py
@@ -42,14 +42,13 @@ class KubespiderDownloader:
             provider = list(filter(lambda p: p.get_provider_name() in name_list, self.download_providers))
         else:
             provider = self.download_providers
-        
         if provider_type is not None:
             provider = list(filter(lambda p: p.get_provider_type() == provider_type, provider))
         name = list(map(lambda p: p.get_provider_name(), provider))
         logging.info('filtering downloader by name %s type %s, result %s', str(name_list), str(provider_type), str(name))
         return provider
 
-    def download_file(self, url, path, link_type, provider_name=None, provider_type=None, extra_param=None) -> TypeError:        
+    def download_file(self, url, path, link_type, provider_name=None, provider_type=None, extra_param=None) -> TypeError:
         downloader = self.filter_downloader(provider_name, provider_type)
         logging.info('download link type %s, with provider size %s', link_type, len(downloader))
         if link_type == types.LINK_TYPE_TORRENT:

--- a/kubespider/core/download_trigger.py
+++ b/kubespider/core/download_trigger.py
@@ -49,23 +49,23 @@ class KubespiderDownloader:
         logging.info('filtering downloader by name %s type %s, result %s', str(name_list), str(provider_type), str(name))
         return provider
 
-    def download_file(self, url, path, link_type, provider_name=None, provider_type=None) -> TypeError:        
+    def download_file(self, url, path, link_type, provider_name=None, provider_type=None, extra_param=None) -> TypeError:        
         downloader = self.filter_downloader(provider_name, provider_type)
         logging.info('download link type %s, with provider size %s', link_type, len(downloader))
         if link_type == types.LINK_TYPE_TORRENT:
-            return self.handle_torrent_download(url, path, downloader)
+            return self.handle_torrent_download(url, path, downloader, extra_param)
 
         if link_type == types.LINK_TYPE_MAGNET:
-            return self.handle_magnet_download(url, path, downloader)
+            return self.handle_magnet_download(url, path, downloader, extra_param)
 
         if link_type == types.LINK_TYPE_GENERAL:
-            return self.handle_general_download(url, path, downloader)
+            return self.handle_general_download(url, path, downloader, extra_param)
 
         logging.warning("Unknown link type:%s", link_type)
 
         return None
 
-    def handle_torrent_download(self, url, path, downloader: list) -> TypeError:
+    def handle_torrent_download(self, url, path, downloader: list, extra_param=None) -> TypeError:
         tmp_file = helper.get_tmp_file_name(url)
 
         headers = ("User-Agent", "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 Safari/537.36 QIHU 360SE")
@@ -84,31 +84,31 @@ class KubespiderDownloader:
         for provider in downloader:
             logging.info('Download torrent file with downloader(%s)', provider.get_provider_name())
             provider.load_config()
-            err = provider.send_torrent_task(tmp_file, path)
+            err = provider.send_torrent_task(tmp_file, path, extra_param)
             if err is not None:
                 logging.warning('Download torrent file error:%s', err)
                 continue
             break
         return err
 
-    def handle_magnet_download(self, url, path, downloader=None) -> TypeError:
+    def handle_magnet_download(self, url, path, downloader=None, extra_param=None) -> TypeError:
         err = None
         for provider in downloader:
             logging.info('Download mangent file with downloader(%s)', provider.get_provider_name())
             provider.load_config()
-            err = provider.send_magnet_task(url, path)
+            err = provider.send_magnet_task(url, path, extra_param)
             if err is not None:
                 logging.warning('Download torrent file error:%s', err)
                 continue
             break
         return err
 
-    def handle_general_download(self, url, path, downloader=None) -> TypeError:
+    def handle_general_download(self, url, path, downloader=None, extra_param=None) -> TypeError:
         err = None
         for provider in downloader:
             logging.info('Download general file with downloader(%s)', provider.get_provider_name())
             provider.load_config()
-            err = provider.send_general_task(url, path)
+            err = provider.send_general_task(url, path, extra_param)
             if err is not None:
                 logging.warning('Download torrent file error:%s', err)
                 continue

--- a/kubespider/core/kubespider_global.py
+++ b/kubespider/core/kubespider_global.py
@@ -9,20 +9,48 @@ import download_provider.xunlei_download_provider.provider as xunlei_download_pr
 import download_provider.qbittorrent_download_provider.provider as qbittorrent_download_provider
 import download_provider.youget_download_provider.provider as youget_download_provider
 
-source_providers = [
-    mikanani_source_provider.MikananiSourceProvider(),
-    btbtt12_disposable_source_provider.Btbtt12DisposableSourceProvider(),
-    meijutt_source_provider.MeijuttSourceProvider(),
-    bilibili_source_provider.BilibiliSourceProvider(),
-    youtube_source_provider.YouTubeSourceProvider(),
-]
+from utils import helper
+from utils.helper import Config
 
-download_providers = [
-    aria2_download_provider.Aria2DownloadProvider(),
-    xunlei_download_provider.XunleiDownloadProvider(),
-    qbittorrent_download_provider.QbittorrentDownloadProvider(),
-    youget_download_provider.YougetDownloadProvider(),
-]
+def get_source_provider(name: str, config: dict):
+    type = config['type']
+    if type == 'bilibili_source_provider':
+        return bilibili_source_provider.BilibiliSourceProvider(name)
+    elif type == 'btbtt12_disposable_source_provider':
+        return btbtt12_disposable_source_provider.Btbtt12DisposableSourceProvider(name)
+    elif type == 'meijutt_source_provider':
+        return meijutt_source_provider.MeijuttSourceProvider(name)
+    elif type == 'mikanani_source_provider':
+        return mikanani_source_provider.MikananiSourceProvider(name)
+    elif type == 'youtube_source_provider':
+        return youget_download_provider.YougetDownloadProvider(name)
+    raise Exception(str('unknown source provider type %s', type))
+
+source_providers = []
+
+source_config = helper.load_config(Config.SOURCE_PROVIDER)
+for name in source_config:
+    source_providers.append(get_source_provider(name, source_config[name]))
+
+
+def get_download_provider(name: str, config: dict):
+    type = config['type']
+    if type == 'aria2_download_provider':
+        return aria2_download_provider.Aria2DownloadProvider(name)
+    elif type == 'qbittorrent_download_provider':
+        return qbittorrent_download_provider.QbittorrentDownloadProvider(name)
+    elif type == 'xunlei_download_provider':
+        return xunlei_download_provider.XunleiDownloadProvider(name)
+    elif type == 'youget_download_provider':
+        return youget_download_provider.YougetDownloadProvider(name)
+    raise Exception(str('unknown download provider type %s', type))
+
+
+download_providers = []
+
+download_config = helper.load_config(Config.DOWNLOAD_PROVIDER)
+for name in download_config:
+    download_providers.append(get_download_provider(name, download_config[name]))
 
 enabled_source_provider = []
 enabled_download_provider = []

--- a/kubespider/core/kubespider_global.py
+++ b/kubespider/core/kubespider_global.py
@@ -24,8 +24,8 @@ def get_source_provider(provider_name: str, config: dict):
     provider_type = config['type']
     try:
         return source_provider_init_func[provider_type](provider_name)
-    except:
-        raise Exception(str('unknown source provider type %s', provider_type))
+    except Exception as exc:
+        raise Exception(str('unknown source provider type %s', provider_type)) from exc
 
 source_providers = []
 
@@ -44,8 +44,8 @@ def get_download_provider(provider_name: str, config: dict):
     provider_type = config['type']
     try:
         return downloader_provider_init_func[provider_type](provider_name)
-    except:
-        raise Exception(str('unknown download provider type %s', provider_type))
+    except Exception as exc:
+        raise Exception(str('unknown download provider type %s', provider_type)) from exc
 
 
 download_providers = []

--- a/kubespider/core/kubespider_global.py
+++ b/kubespider/core/kubespider_global.py
@@ -12,19 +12,19 @@ import download_provider.youget_download_provider.provider as youget_download_pr
 from utils import helper
 from utils.helper import Config
 
-def get_source_provider(name: str, config: dict):
-    type = config['type']
-    if type == 'bilibili_source_provider':
-        return bilibili_source_provider.BilibiliSourceProvider(name)
-    elif type == 'btbtt12_disposable_source_provider':
-        return btbtt12_disposable_source_provider.Btbtt12DisposableSourceProvider(name)
-    elif type == 'meijutt_source_provider':
-        return meijutt_source_provider.MeijuttSourceProvider(name)
-    elif type == 'mikanani_source_provider':
-        return mikanani_source_provider.MikananiSourceProvider(name)
-    elif type == 'youtube_source_provider':
-        return youget_download_provider.YougetDownloadProvider(name)
-    raise Exception(str('unknown source provider type %s', type))
+def get_source_provider(provider_name: str, config: dict):
+    provider_type = config['type']
+    if provider_type == 'bilibili_source_provider':
+        return bilibili_source_provider.BilibiliSourceProvider(provider_name)
+    if provider_type == 'btbtt12_disposable_source_provider':
+        return btbtt12_disposable_source_provider.Btbtt12DisposableSourceProvider(provider_name)
+    if provider_type == 'meijutt_source_provider':
+        return meijutt_source_provider.MeijuttSourceProvider(provider_name)
+    if provider_type == 'mikanani_source_provider':
+        return mikanani_source_provider.MikananiSourceProvider(provider_name)
+    if provider_type == 'youtube_source_provider':
+        return youtube_source_provider.YouTubeSourceProvider(provider_name)
+    raise Exception(str('unknown source provider type %s', provider_type))
 
 source_providers = []
 
@@ -33,17 +33,17 @@ for name in source_config:
     source_providers.append(get_source_provider(name, source_config[name]))
 
 
-def get_download_provider(name: str, config: dict):
-    type = config['type']
-    if type == 'aria2_download_provider':
-        return aria2_download_provider.Aria2DownloadProvider(name)
-    elif type == 'qbittorrent_download_provider':
-        return qbittorrent_download_provider.QbittorrentDownloadProvider(name)
-    elif type == 'xunlei_download_provider':
-        return xunlei_download_provider.XunleiDownloadProvider(name)
-    elif type == 'youget_download_provider':
-        return youget_download_provider.YougetDownloadProvider(name)
-    raise Exception(str('unknown download provider type %s', type))
+def get_download_provider(provider_name: str, config: dict):
+    provider_type = config['type']
+    if provider_type == 'aria2_download_provider':
+        return aria2_download_provider.Aria2DownloadProvider(provider_name)
+    if provider_type == 'qbittorrent_download_provider':
+        return qbittorrent_download_provider.QbittorrentDownloadProvider(provider_name)
+    if provider_type == 'xunlei_download_provider':
+        return xunlei_download_provider.XunleiDownloadProvider(provider_name)
+    if provider_type == 'youget_download_provider':
+        return youget_download_provider.YougetDownloadProvider(provider_name)
+    raise Exception(str('unknown download provider type %s', provider_type))
 
 
 download_providers = []

--- a/kubespider/core/kubespider_global.py
+++ b/kubespider/core/kubespider_global.py
@@ -12,19 +12,20 @@ import download_provider.youget_download_provider.provider as youget_download_pr
 from utils import helper
 from utils.helper import Config
 
+source_provider_init_func = {
+    'bilibili_source_provider': bilibili_source_provider.BilibiliSourceProvider,
+    'btbtt12_disposable_source_provider': btbtt12_disposable_source_provider.Btbtt12DisposableSourceProvider,
+    'meijutt_source_provider': meijutt_source_provider.MeijuttSourceProvider,
+    'mikanani_source_provider': mikanani_source_provider.MikananiSourceProvider,
+    'youtube_source_provider': youtube_source_provider.YouTubeSourceProvider
+}
+
 def get_source_provider(provider_name: str, config: dict):
     provider_type = config['type']
-    if provider_type == 'bilibili_source_provider':
-        return bilibili_source_provider.BilibiliSourceProvider(provider_name)
-    if provider_type == 'btbtt12_disposable_source_provider':
-        return btbtt12_disposable_source_provider.Btbtt12DisposableSourceProvider(provider_name)
-    if provider_type == 'meijutt_source_provider':
-        return meijutt_source_provider.MeijuttSourceProvider(provider_name)
-    if provider_type == 'mikanani_source_provider':
-        return mikanani_source_provider.MikananiSourceProvider(provider_name)
-    if provider_type == 'youtube_source_provider':
-        return youtube_source_provider.YouTubeSourceProvider(provider_name)
-    raise Exception(str('unknown source provider type %s', provider_type))
+    try:
+        return source_provider_init_func[provider_type](provider_name)
+    except:
+        raise Exception(str('unknown source provider type %s', provider_type))
 
 source_providers = []
 
@@ -32,18 +33,19 @@ source_config = helper.load_config(Config.SOURCE_PROVIDER)
 for name in source_config:
     source_providers.append(get_source_provider(name, source_config[name]))
 
+downloader_provider_init_func = {
+    'aria2_download_provider': aria2_download_provider.Aria2DownloadProvider,
+    'qbittorrent_download_provider': qbittorrent_download_provider.QbittorrentDownloadProvider,
+    'xunlei_download_provider': xunlei_download_provider.XunleiDownloadProvider,
+    'youget_download_provider': youget_download_provider.YougetDownloadProvider
+}
 
 def get_download_provider(provider_name: str, config: dict):
     provider_type = config['type']
-    if provider_type == 'aria2_download_provider':
-        return aria2_download_provider.Aria2DownloadProvider(provider_name)
-    if provider_type == 'qbittorrent_download_provider':
-        return qbittorrent_download_provider.QbittorrentDownloadProvider(provider_name)
-    if provider_type == 'xunlei_download_provider':
-        return xunlei_download_provider.XunleiDownloadProvider(provider_name)
-    if provider_type == 'youget_download_provider':
-        return youget_download_provider.YougetDownloadProvider(provider_name)
-    raise Exception(str('unknown download provider type %s', provider_type))
+    try:
+        return downloader_provider_init_func[provider_type](provider_name)
+    except:
+        raise Exception(str('unknown download provider type %s', provider_type))
 
 
 download_providers = []

--- a/kubespider/core/period_server.py
+++ b/kubespider/core/period_server.py
@@ -45,9 +45,6 @@ class PeriodServer:
         provider.load_config()
         links = provider.get_links("")
         link_type = provider.get_link_type()
-        specific_download_provider_type = provider.get_download_provider_type()
-        specific_download_provider_name = provider.get_prefer_download_provider()
-        extras = provider.get_download_param()
 
         provider_name = provider.get_provider_name()
         state = self.load_state(provider_name)
@@ -61,8 +58,7 @@ class PeriodServer:
             download_final_path = helper.convert_file_type_to_path(source['file_type']) + '/' + source['path']
             err = download_trigger.kubespider_downloader. \
                 download_file(source['link'], download_final_path, \
-                              link_type, specific_download_provider_name,\
-                                specific_download_provider_type, extras)
+                              link_type, provider)
             if err is not None:
                 break
             state.append(helper.get_unique_hash(source['link']))

--- a/kubespider/core/period_server.py
+++ b/kubespider/core/period_server.py
@@ -39,13 +39,14 @@ class PeriodServer:
         self.queue.put(True)
 
     def run_single_provider(self, provider: sp.SourceProvider) -> TypeError:
-        if provider.get_provider_type() != types.SOURCE_PROVIDER_PERIOD_TYPE:
+        if provider.get_provider_listen_type() != types.SOURCE_PROVIDER_PERIOD_TYPE:
             return None
 
         provider.load_config()
         links = provider.get_links("")
         link_type = provider.get_link_type()
-        specific_download_provider = provider.get_download_provider()
+        specific_download_provider_type = provider.get_download_provider_type()
+        specific_download_provider_name = provider.get_prefer_download_provider()
 
         provider_name = provider.get_provider_name()
         state = self.load_state(provider_name)
@@ -59,7 +60,8 @@ class PeriodServer:
             download_final_path = helper.convert_file_type_to_path(source['file_type']) + '/' + source['path']
             err = download_trigger.kubespider_downloader. \
                 download_file(source['link'], download_final_path, \
-                              link_type, specific_download_provider)
+                              link_type, specific_download_provider_name,\
+                                specific_download_provider_type)
             if err is not None:
                 break
             state.append(helper.get_unique_hash(source['link']))

--- a/kubespider/core/period_server.py
+++ b/kubespider/core/period_server.py
@@ -47,6 +47,7 @@ class PeriodServer:
         link_type = provider.get_link_type()
         specific_download_provider_type = provider.get_download_provider_type()
         specific_download_provider_name = provider.get_prefer_download_provider()
+        extras = provider.get_download_param()
 
         provider_name = provider.get_provider_name()
         state = self.load_state(provider_name)
@@ -61,7 +62,7 @@ class PeriodServer:
             err = download_trigger.kubespider_downloader. \
                 download_file(source['link'], download_final_path, \
                               link_type, specific_download_provider_name,\
-                                specific_download_provider_type)
+                                specific_download_provider_type, extras)
             if err is not None:
                 break
             state.append(helper.get_unique_hash(source['link']))

--- a/kubespider/core/webhook_server.py
+++ b/kubespider/core/webhook_server.py
@@ -84,6 +84,7 @@ def download_links_with_provider(source: str, source_provider: sp.SourceProvider
     links = source_provider.get_links(source)
     specific_download_provider_type = source_provider.get_download_provider_type()
     specific_download_provider_name = source_provider.get_prefer_download_provider()
+    extras = source_provider.get_download_param()
     for download_link in links:
         # The path rule should be like: {file_type}/{file_title}
         download_final_path = helper.convert_file_type_to_path(download_link['file_type']) + '/' + download_link['path']
@@ -91,7 +92,7 @@ def download_links_with_provider(source: str, source_provider: sp.SourceProvider
             download_file(download_link['link'], \
                           download_final_path, link_type,\
                           specific_download_provider_name,\
-                            specific_download_provider_type)
+                            specific_download_provider_type, extras)
         if err is not None:
             return err
     return None

--- a/kubespider/core/webhook_server.py
+++ b/kubespider/core/webhook_server.py
@@ -82,14 +82,16 @@ def refresh_handler():
 def download_links_with_provider(source: str, source_provider: sp.SourceProvider):
     link_type = source_provider.get_link_type()
     links = source_provider.get_links(source)
-    specific_download_provider = source_provider.get_download_provider()
+    specific_download_provider_type = source_provider.get_download_provider_type()
+    specific_download_provider_name = source_provider.get_prefer_download_provider()
     for download_link in links:
         # The path rule should be like: {file_type}/{file_title}
         download_final_path = helper.convert_file_type_to_path(download_link['file_type']) + '/' + download_link['path']
         err = download_trigger.kubespider_downloader.\
             download_file(download_link['link'], \
                           download_final_path, link_type,\
-                            specific_download_provider)
+                          specific_download_provider_name,\
+                            specific_download_provider_type)
         if err is not None:
             return err
     return None

--- a/kubespider/core/webhook_server.py
+++ b/kubespider/core/webhook_server.py
@@ -82,17 +82,13 @@ def refresh_handler():
 def download_links_with_provider(source: str, source_provider: sp.SourceProvider):
     link_type = source_provider.get_link_type()
     links = source_provider.get_links(source)
-    specific_download_provider_type = source_provider.get_download_provider_type()
-    specific_download_provider_name = source_provider.get_prefer_download_provider()
-    extras = source_provider.get_download_param()
     for download_link in links:
         # The path rule should be like: {file_type}/{file_title}
         download_final_path = helper.convert_file_type_to_path(download_link['file_type']) + '/' + download_link['path']
         err = download_trigger.kubespider_downloader.\
             download_file(download_link['link'], \
                           download_final_path, link_type,\
-                          specific_download_provider_name,\
-                            specific_download_provider_type, extras)
+                          source_provider)
         if err is not None:
             return err
     return None

--- a/kubespider/download_provider/aria2_download_provider/provider.py
+++ b/kubespider/download_provider/aria2_download_provider/provider.py
@@ -55,7 +55,7 @@ class Aria2DownloadProvider(provider.DownloadProvider):
 
         return defective_tasks
 
-    def send_torrent_task(self, torrent_file_path: str, download_path: str) -> TypeError:
+    def send_torrent_task(self, torrent_file_path: str, download_path: str, extra_param=None) -> TypeError:
         logging.info('Start torrent download:%s', torrent_file_path)
         download_path = os.path.join(self.download_base_path, download_path)
         try:
@@ -67,7 +67,7 @@ class Aria2DownloadProvider(provider.DownloadProvider):
             return err
         return None
 
-    def send_magnet_task(self, url: str, path: str) -> TypeError:
+    def send_magnet_task(self, url: str, path: str, extra_param=None) -> TypeError:
         logging.info('Start magnet download:%s', url)
         download_path = os.path.join(self.download_base_path, path)
         try:
@@ -78,7 +78,7 @@ class Aria2DownloadProvider(provider.DownloadProvider):
             logging.warning('Please ensure your aria2 server is ok:%s', err)
             return err
 
-    def send_general_task(self, url: str, path: str) -> TypeError:
+    def send_general_task(self, url: str, path: str, extra_param=None) -> TypeError:
         logging.info('Start general file download:%s', url)
 
         if not url.startswith('http'):

--- a/kubespider/download_provider/aria2_download_provider/provider.py
+++ b/kubespider/download_provider/aria2_download_provider/provider.py
@@ -19,7 +19,7 @@ class Aria2DownloadProvider(provider.DownloadProvider):
 
     def get_provider_name(self) -> str:
         return self.provider_name
-    
+
     def get_provider_type(self) -> str:
         return self.provider_type
 

--- a/kubespider/download_provider/aria2_download_provider/provider.py
+++ b/kubespider/download_provider/aria2_download_provider/provider.py
@@ -8,8 +8,9 @@ from api import types
 
 
 class Aria2DownloadProvider(provider.DownloadProvider):
-    def __init__(self) -> None:
-        self.provider_name = 'aria2_download_provider'
+    def __init__(self, name: str) -> None:
+        self.provider_name = name
+        self.provider_type = 'aria2_download_provider'
         self.rpc_endpoint_host = ''
         self.rpc_endpoint_port = 0
         self.download_base_path = ''
@@ -18,6 +19,9 @@ class Aria2DownloadProvider(provider.DownloadProvider):
 
     def get_provider_name(self) -> str:
         return self.provider_name
+    
+    def get_provider_type(self) -> str:
+        return self.provider_type
 
     def provider_enabled(self) -> bool:
         cfg = provider.load_download_provider_config(self.provider_name)

--- a/kubespider/download_provider/provider.py
+++ b/kubespider/download_provider/provider.py
@@ -35,15 +35,15 @@ class DownloadProvider(metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
-    def send_torrent_task(self, torrent_file_path, download_path) -> TypeError:
+    def send_torrent_task(self, torrent_file_path, download_path, extra_param=None) -> TypeError:
         pass
 
     @abc.abstractmethod
-    def send_magnet_task(self, url: str, path: str) -> TypeError:
+    def send_magnet_task(self, url: str, path: str, extra_param=None) -> TypeError:
         pass
 
     @abc.abstractmethod
-    def send_general_task(self, url: str, path: str) -> TypeError:
+    def send_general_task(self, url: str, path: str, extra_param=None) -> TypeError:
         pass
 
     @abc.abstractmethod

--- a/kubespider/download_provider/provider.py
+++ b/kubespider/download_provider/provider.py
@@ -9,8 +9,14 @@ class DownloadProvider(metaclass=abc.ABCMeta):
     def __init__(self) -> None:
         pass
 
+    # 配置中声明的名字
     @abc.abstractmethod
     def get_provider_name(self) -> str:
+        pass
+
+    # 下载器类型
+    @abc.abstractmethod
+    def get_provider_type(self) -> str:
         pass
 
     @abc.abstractmethod

--- a/kubespider/download_provider/provider.py
+++ b/kubespider/download_provider/provider.py
@@ -9,14 +9,14 @@ class DownloadProvider(metaclass=abc.ABCMeta):
     def __init__(self) -> None:
         pass
 
-    # 配置中声明的名字
     @abc.abstractmethod
     def get_provider_name(self) -> str:
+        # name of download provider defined in config
         pass
 
-    # 下载器类型
     @abc.abstractmethod
     def get_provider_type(self) -> str:
+        # type of downloader
         pass
 
     @abc.abstractmethod

--- a/kubespider/download_provider/qbittorrent_download_provider/provider.py
+++ b/kubespider/download_provider/qbittorrent_download_provider/provider.py
@@ -64,12 +64,19 @@ class QbittorrentDownloadProvider(
                     continue
         return defective_tasks
 
-    def send_torrent_task(self, torrent_file_path: str, download_path: str) -> TypeError:
+    def send_torrent_task(self, torrent_file_path: str, download_path: str, extra_param=None) -> TypeError:
         download_path = os.path.join(self.download_base_path, download_path)
         logging.info('Start torrent download:%s, path:%s', torrent_file_path, download_path)
+        tags = []
+        if extra_param is not None:
+            category = extra_param.get('category', self.download_category)
+            tags += extra_param.get('tags', [])
+        else:
+            category = self.download_category
+        tags += self.download_tags
         try:
-            logging.info('Create download task category:%s, tags:%s', self.download_category, self.download_tags)
-            ret = self.client.torrents_add(torrent_files=torrent_file_path, save_path=download_path, category=self.download_category, tags=self.download_tags)
+            logging.info('Create download task category:%s, tags:%s', category, tags)
+            ret = self.client.torrents_add(torrent_files=torrent_file_path, save_path=download_path, category=category, tags=tags)
             logging.info('Create download task results:%s', ret)
             return None
         except Exception as err:
@@ -77,12 +84,19 @@ class QbittorrentDownloadProvider(
             return err
         return None
 
-    def send_magnet_task(self, url: str, path: str) -> TypeError:
+    def send_magnet_task(self, url: str, path: str, extra_param=None) -> TypeError:
         logging.info('Start magent download:%s, path:%s', url, path)
         download_path = os.path.join(self.download_base_path, path)
+        tags = []
+        if extra_param is not None:
+            category = extra_param.get('category', self.download_category)
+            tags += extra_param.get('tags', [])
+        else:
+            category = self.download_category
+        tags += self.download_tags
         try:
-            logging.info('Create download task category:%s, tags:%s', self.download_category, self.download_tags)
-            ret = self.client.torrents_add(urls=url, save_path=download_path, category=self.download_category, tags=self.download_tags)
+            logging.info('Create download task category:%s, tags:%s', category, tags)
+            ret = self.client.torrents_add(urls=url, save_path=download_path, category=category, tags=tags)
             logging.info('Create download task results:%s', ret)
             return None
         except Exception as err:
@@ -90,7 +104,7 @@ class QbittorrentDownloadProvider(
             return err
         return None
 
-    def send_general_task(self, url: str, path: str) -> TypeError:
+    def send_general_task(self, url: str, path: str, extra_param=None) -> TypeError:
         logging.warning('qbittorrent not support generatl task download! Please use aria2 or else download provider')
         return TypeError('qbittorrent not support generate task download')
 

--- a/kubespider/download_provider/qbittorrent_download_provider/provider.py
+++ b/kubespider/download_provider/qbittorrent_download_provider/provider.py
@@ -11,8 +11,9 @@ from api import types
 class QbittorrentDownloadProvider(
         provider.DownloadProvider # pylint length
     ):
-    def __init__(self) -> None:
-        self.provider_name = 'qbittorrent_download_provider'
+    def __init__(self, name: str) -> None:
+        self.provider_name = name
+        self.provider_type = 'qbittorrent_download_provider'
         self.http_endpoint_host = ''
         self.http_endpoint_port = 0
         self.client = None
@@ -25,6 +26,9 @@ class QbittorrentDownloadProvider(
 
     def get_provider_name(self) -> str:
         return self.provider_name
+    
+    def get_provider_type(self) -> str:
+        return self.provider_type
 
     def provider_enabled(self) -> bool:
         cfg = provider.load_download_provider_config(self.provider_name)

--- a/kubespider/download_provider/qbittorrent_download_provider/provider.py
+++ b/kubespider/download_provider/qbittorrent_download_provider/provider.py
@@ -26,7 +26,7 @@ class QbittorrentDownloadProvider(
 
     def get_provider_name(self) -> str:
         return self.provider_name
-    
+
     def get_provider_type(self) -> str:
         return self.provider_type
 

--- a/kubespider/download_provider/xunlei_download_provider/provider.py
+++ b/kubespider/download_provider/xunlei_download_provider/provider.py
@@ -21,7 +21,7 @@ class XunleiDownloadProvider(provider.DownloadProvider):
 
     def get_provider_name(self) -> str:
         return self.provider_name
-    
+
     def get_provider_type(self) -> str:
         return self.provider_type
 

--- a/kubespider/download_provider/xunlei_download_provider/provider.py
+++ b/kubespider/download_provider/xunlei_download_provider/provider.py
@@ -12,14 +12,18 @@ from download_provider import provider
 
 
 class XunleiDownloadProvider(provider.DownloadProvider):
-    def __init__(self) -> None:
-        self.provider_name = 'xunlei_download_provider'
+    def __init__(self, name: str) -> None:
+        self.provider_name = name
+        self.provider_type = 'xunlei_download_provider'
         self.http_endpoint = ''
         self.device_id = ''
         self.js_ctx = execjs.compile('')
 
     def get_provider_name(self) -> str:
         return self.provider_name
+    
+    def get_provider_type(self) -> str:
+        return self.provider_type
 
     def provider_enabled(self) -> bool:
         cfg = provider.load_download_provider_config(self.provider_name)

--- a/kubespider/download_provider/xunlei_download_provider/provider.py
+++ b/kubespider/download_provider/xunlei_download_provider/provider.py
@@ -37,7 +37,7 @@ class XunleiDownloadProvider(provider.DownloadProvider):
         # if xunlei doesn't work, it means other tools couldn't, so just ignore it.
         return []
 
-    def send_torrent_task(self, torrent_file_path: str, download_path: str) -> TypeError:
+    def send_torrent_task(self, torrent_file_path: str, download_path: str, extra_param=None) -> TypeError:
         logging.info('Start torrent download:%s', torrent_file_path)
         token = self.get_pan_token()
         if token == "":
@@ -46,7 +46,7 @@ class XunleiDownloadProvider(provider.DownloadProvider):
         file_info = self.list_files(token, magnet_url)
         return self.send_task(token, file_info, magnet_url, download_path)
 
-    def send_magnet_task(self, url: str, path: str) -> TypeError:
+    def send_magnet_task(self, url: str, path: str, extra_param=None) -> TypeError:
         logging.info('Start magnet download:%s', url)
         token = self.get_pan_token()
         if token == "":
@@ -54,7 +54,7 @@ class XunleiDownloadProvider(provider.DownloadProvider):
         file_info = self.list_files(token, url)
         return self.send_task(token, file_info, url, path)
 
-    def send_general_task(self, url: str, path: str) -> TypeError:
+    def send_general_task(self, url: str, path: str, extra_param=None) -> TypeError:
         logging.info('Start general file download:%s', url)
         token = self.get_pan_token()
         if token == "":

--- a/kubespider/download_provider/youget_download_provider/provider.py
+++ b/kubespider/download_provider/youget_download_provider/provider.py
@@ -9,13 +9,17 @@ from download_provider import provider
 class YougetDownloadProvider(
         provider.DownloadProvider # pylint length
     ):
-    def __init__(self) -> None:
-        self.provider_name = 'youget_download_provider'
+    def __init__(self, name: str) -> None:
+        self.provider_name = name
+        self.provider_type = 'youget_download_provider'
         self.http_endpoint_host = ''
         self.http_endpoint_port = 0
 
     def get_provider_name(self) -> str:
         return self.provider_name
+    
+    def get_provider_type(self) -> str:
+        return self.provider_type
 
     def provider_enabled(self) -> bool:
         cfg = provider.load_download_provider_config(self.provider_name)

--- a/kubespider/download_provider/youget_download_provider/provider.py
+++ b/kubespider/download_provider/youget_download_provider/provider.py
@@ -17,7 +17,7 @@ class YougetDownloadProvider(
 
     def get_provider_name(self) -> str:
         return self.provider_name
-    
+
     def get_provider_type(self) -> str:
         return self.provider_type
 

--- a/kubespider/download_provider/youget_download_provider/provider.py
+++ b/kubespider/download_provider/youget_download_provider/provider.py
@@ -33,13 +33,13 @@ class YougetDownloadProvider(
         # These tasks is special, other download software could not handle
         return {}
 
-    def send_torrent_task(self, torrent_file_path, download_path) -> TypeError:
+    def send_torrent_task(self, torrent_file_path, download_path, extra_param=None) -> TypeError:
         return TypeError("youget doesn't support torrent task")
 
-    def send_magnet_task(self, url: str, path: str) -> TypeError:
+    def send_magnet_task(self, url: str, path: str, extra_param=None) -> TypeError:
         return TypeError("youget doesn't support magnet task")
 
-    def send_general_task(self, url: str, path: str) -> TypeError:
+    def send_general_task(self, url: str, path: str, extra_param=None) -> TypeError:
         headers = {'Content-Type': 'application/json'}
         data = {'dataSource': url, 'path': path}
         logging.info('Send general task:%s', json.dumps(data))

--- a/kubespider/source_provider/bilibili_source_provider/provider.py
+++ b/kubespider/source_provider/bilibili_source_provider/provider.py
@@ -18,7 +18,7 @@ class BilibiliSourceProvider(provider.SourceProvider):
 
     def get_provider_name(self) -> str:
         return self.provider_name
-    
+
     def get_provider_type(self) -> str:
         return self.provider_type
 
@@ -27,7 +27,7 @@ class BilibiliSourceProvider(provider.SourceProvider):
 
     def get_download_provider_type(self) -> str:
         return "youget_download_provider"
-    
+
     def get_prefer_download_provider(self) -> list:
         cfg = provider.load_source_provide_config(self.provider_name)
         return cfg.get('downloader')

--- a/kubespider/source_provider/bilibili_source_provider/provider.py
+++ b/kubespider/source_provider/bilibili_source_provider/provider.py
@@ -9,20 +9,28 @@ from api import types
 
 
 class BilibiliSourceProvider(provider.SourceProvider):
-    def __init__(self) -> None:
-        self.provider_type = types.SOURCE_PROVIDER_DISPOSABLE_TYPE
+    def __init__(self, name: str) -> None:
+        self.provider_listen_type = types.SOURCE_PROVIDER_DISPOSABLE_TYPE
         self.link_type = types.LINK_TYPE_GENERAL
         self.webhook_enable = True
-        self.provider_name = 'bilibili_source_provider'
+        self.provider_type = 'bilibili_source_provider'
+        self.provider_name = name
 
     def get_provider_name(self) -> str:
         return self.provider_name
-
+    
     def get_provider_type(self) -> str:
         return self.provider_type
 
-    def get_download_provider(self) -> str:
+    def get_provider_listen_type(self) -> str:
+        return self.provider_listen_type
+
+    def get_download_provider_type(self) -> str:
         return "youget_download_provider"
+    
+    def get_prefer_download_provider(self) -> list:
+        cfg = provider.load_source_provide_config(self.provider_name)
+        return cfg['downloader']
 
     def get_link_type(self) -> str:
         return self.link_type

--- a/kubespider/source_provider/bilibili_source_provider/provider.py
+++ b/kubespider/source_provider/bilibili_source_provider/provider.py
@@ -30,14 +30,18 @@ class BilibiliSourceProvider(provider.SourceProvider):
     
     def get_prefer_download_provider(self) -> list:
         cfg = provider.load_source_provide_config(self.provider_name)
-        return cfg['downloader']
+        return cfg.get('downloader')
+
+    def get_download_param(self) -> list:
+        cfg = provider.load_source_provide_config(self.provider_name)
+        return cfg.get('download_param')
 
     def get_link_type(self) -> str:
         return self.link_type
 
     def provider_enabled(self) -> bool:
         cfg = provider.load_source_provide_config(self.provider_name)
-        return cfg['enable']
+        return cfg.get('enable', True)
 
     def is_webhook_enable(self) -> bool:
         return self.webhook_enable

--- a/kubespider/source_provider/btbtt12_disposable_source_provider/provider.py
+++ b/kubespider/source_provider/btbtt12_disposable_source_provider/provider.py
@@ -21,7 +21,7 @@ class Btbtt12DisposableSourceProvider(provider.SourceProvider):
 
     def get_provider_name(self) -> str:
         return self.provider_name
-    
+
     def get_provider_type(self) -> str:
         return self.provider_type
 
@@ -30,7 +30,7 @@ class Btbtt12DisposableSourceProvider(provider.SourceProvider):
 
     def get_download_provider_type(self) -> str:
         return None
-    
+
     def get_prefer_download_provider(self) -> list:
         cfg = provider.load_source_provide_config(self.provider_name)
         return cfg.get('downloader')

--- a/kubespider/source_provider/btbtt12_disposable_source_provider/provider.py
+++ b/kubespider/source_provider/btbtt12_disposable_source_provider/provider.py
@@ -12,20 +12,28 @@ from api import types
 
 
 class Btbtt12DisposableSourceProvider(provider.SourceProvider):
-    def __init__(self) -> None:
-        self.provider_type = types.SOURCE_PROVIDER_DISPOSABLE_TYPE
+    def __init__(self, name: str) -> None:
+        self.provider_listen_type = types.SOURCE_PROVIDER_DISPOSABLE_TYPE
         self.link_type = types.LINK_TYPE_TORRENT
         self.webhook_enable = True
-        self.provider_name = 'btbtt12_disposable_source_provider'
+        self.provider_type = 'btbtt12_disposable_source_provider'
+        self.provider_name = name
 
     def get_provider_name(self) -> str:
         return self.provider_name
-
+    
     def get_provider_type(self) -> str:
         return self.provider_type
 
-    def get_download_provider(self) -> str:
+    def get_provider_listen_type(self) -> str:
+        return self.provider_listen_type
+
+    def get_download_provider_type(self) -> str:
         return None
+    
+    def get_prefer_download_provider(self) -> list:
+        cfg = provider.load_source_provide_config(self.provider_name)
+        return cfg['downloader']
 
     def get_link_type(self) -> str:
         return self.link_type

--- a/kubespider/source_provider/btbtt12_disposable_source_provider/provider.py
+++ b/kubespider/source_provider/btbtt12_disposable_source_provider/provider.py
@@ -33,14 +33,18 @@ class Btbtt12DisposableSourceProvider(provider.SourceProvider):
     
     def get_prefer_download_provider(self) -> list:
         cfg = provider.load_source_provide_config(self.provider_name)
-        return cfg['downloader']
+        return cfg.get('downloader')
+
+    def get_download_param(self) -> list:
+        cfg = provider.load_source_provide_config(self.provider_name)
+        return cfg.get('download_param')
 
     def get_link_type(self) -> str:
         return self.link_type
 
     def provider_enabled(self) -> bool:
         cfg = provider.load_source_provide_config(self.provider_name)
-        return cfg['enable']
+        return cfg.get('enable', True)
 
     def is_webhook_enable(self) -> bool:
         return self.webhook_enable

--- a/kubespider/source_provider/meijutt_source_provider/provider.py
+++ b/kubespider/source_provider/meijutt_source_provider/provider.py
@@ -22,7 +22,7 @@ class MeijuttSourceProvider(provider.SourceProvider):
 
     def get_provider_name(self) -> str:
         return self.provider_name
-    
+
     def get_provider_type(self) -> str:
         return self.provider_type
 
@@ -31,7 +31,7 @@ class MeijuttSourceProvider(provider.SourceProvider):
 
     def get_download_provider_type(self) -> str:
         return None
-    
+
     def get_prefer_download_provider(self) -> list:
         cfg = provider.load_source_provide_config(self.provider_name)
         return cfg.get('downloader')

--- a/kubespider/source_provider/meijutt_source_provider/provider.py
+++ b/kubespider/source_provider/meijutt_source_provider/provider.py
@@ -12,21 +12,29 @@ from utils import helper
 
 
 class MeijuttSourceProvider(provider.SourceProvider):
-    def __init__(self) -> None:
-        self.provider_type = types.SOURCE_PROVIDER_PERIOD_TYPE
+    def __init__(self, name: str) -> None:
+        self.provider_listen_type = types.SOURCE_PROVIDER_PERIOD_TYPE
         self.link_type = types.LINK_TYPE_MAGNET
         self.webhook_enable = True
-        self.provider_name = 'meijutt_source_provider'
+        self.provider_type = 'meijutt_source_provider'
         self.tv_links = []
+        self.provider_name = name
 
     def get_provider_name(self) -> str:
         return self.provider_name
-
+    
     def get_provider_type(self) -> str:
         return self.provider_type
 
-    def get_download_provider(self) -> str:
+    def get_provider_listen_type(self) -> str:
+        return self.provider_listen_type
+
+    def get_download_provider_type(self) -> str:
         return None
+    
+    def get_prefer_download_provider(self) -> list:
+        cfg = provider.load_source_provide_config(self.provider_name)
+        return cfg['downloader']
 
     def get_link_type(self) -> str:
         return self.link_type

--- a/kubespider/source_provider/meijutt_source_provider/provider.py
+++ b/kubespider/source_provider/meijutt_source_provider/provider.py
@@ -34,14 +34,18 @@ class MeijuttSourceProvider(provider.SourceProvider):
     
     def get_prefer_download_provider(self) -> list:
         cfg = provider.load_source_provide_config(self.provider_name)
-        return cfg['downloader']
+        return cfg.get('downloader')
+
+    def get_download_param(self) -> list:
+        cfg = provider.load_source_provide_config(self.provider_name)
+        return cfg.get('download_param')
 
     def get_link_type(self) -> str:
         return self.link_type
 
     def provider_enabled(self) -> bool:
         cfg = provider.load_source_provide_config(self.provider_name)
-        return cfg['enable']
+        return cfg.get('enable', True)
 
     def is_webhook_enable(self) -> bool:
         return True

--- a/kubespider/source_provider/mikanani_source_provider/provider.py
+++ b/kubespider/source_provider/mikanani_source_provider/provider.py
@@ -24,7 +24,7 @@ class MikananiSourceProvider(provider.SourceProvider):
 
     def get_provider_name(self) -> str:
         return self.provider_name
-    
+
     def get_provider_type(self) -> str:
         return self.provider_type
 
@@ -33,7 +33,7 @@ class MikananiSourceProvider(provider.SourceProvider):
 
     def get_download_provider_type(self) -> str:
         return None
-    
+
     def get_prefer_download_provider(self) -> list:
         cfg = provider.load_source_provide_config(self.provider_name)
         return cfg.get('downloader')

--- a/kubespider/source_provider/mikanani_source_provider/provider.py
+++ b/kubespider/source_provider/mikanani_source_provider/provider.py
@@ -13,22 +13,30 @@ from utils import helper
 
 
 class MikananiSourceProvider(provider.SourceProvider):
-    def __init__(self) -> None:
-        self.provider_type = types.SOURCE_PROVIDER_PERIOD_TYPE
+    def __init__(self, name: str) -> None:
+        self.provider_listen_type = types.SOURCE_PROVIDER_PERIOD_TYPE
         self.link_type = types.LINK_TYPE_TORRENT
         self.webhook_enable = False
-        self.provider_name = 'mikanani_source_provider'
+        self.provider_type = 'mikanani_source_provider'
         self.rss_link = ''
         self.tmp_file_path = '/tmp/'
+        self.provider_name = name
 
     def get_provider_name(self) -> str:
         return self.provider_name
-
+    
     def get_provider_type(self) -> str:
         return self.provider_type
 
-    def get_download_provider(self) -> str:
+    def get_provider_listen_type(self) -> str:
+        return self.provider_listen_type
+
+    def get_download_provider_type(self) -> str:
         return None
+    
+    def get_prefer_download_provider(self) -> list:
+        cfg = provider.load_source_provide_config(self.provider_name)
+        return cfg['downloader']
 
     def get_link_type(self) -> str:
         return self.link_type

--- a/kubespider/source_provider/mikanani_source_provider/provider.py
+++ b/kubespider/source_provider/mikanani_source_provider/provider.py
@@ -36,14 +36,18 @@ class MikananiSourceProvider(provider.SourceProvider):
     
     def get_prefer_download_provider(self) -> list:
         cfg = provider.load_source_provide_config(self.provider_name)
-        return cfg['downloader']
+        return cfg.get('downloader')
+
+    def get_download_param(self) -> list:
+        cfg = provider.load_source_provide_config(self.provider_name)
+        return cfg.get('download_param')
 
     def get_link_type(self) -> str:
         return self.link_type
 
     def provider_enabled(self) -> bool:
         cfg = provider.load_source_provide_config(self.provider_name)
-        return cfg['enable']
+        return cfg.get('enable', True)
 
     def is_webhook_enable(self) -> bool:
         return self.webhook_enable

--- a/kubespider/source_provider/provider.py
+++ b/kubespider/source_provider/provider.py
@@ -37,6 +37,11 @@ class SourceProvider(metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
+    def get_download_param(self) -> list:
+        # get the specific params for downloader
+        pass
+
+    @abc.abstractmethod
     def get_link_type(self) -> str:
         pass
 

--- a/kubespider/source_provider/provider.py
+++ b/kubespider/source_provider/provider.py
@@ -9,18 +9,31 @@ class SourceProvider(metaclass=abc.ABCMeta):
     def __init__(self) -> None:
         pass
 
+    # 配置中声明的名字
     @abc.abstractmethod
     def get_provider_name(self) -> str:
         pass
 
+    # 订阅源类型
     @abc.abstractmethod
     def get_provider_type(self) -> str:
         pass
 
+    # 订阅源的监听类型，周期订阅or触发式
     @abc.abstractmethod
-    def get_download_provider(self) -> str:
+    def get_provider_listen_type(self) -> str:
+        pass
+
+    @abc.abstractmethod
+    def get_download_provider_type(self) -> str:
         # in general, if this source provider needs to work with specific downlad
-        # provider, return the name of the download provider
+        # provider, return the TYPE of the download provider
+        pass
+
+    @abc.abstractmethod
+    def get_prefer_download_provider(self) -> list:
+        # if the provider is configed to use some specified download providers,
+        # return them here in a list
         pass
 
     @abc.abstractmethod

--- a/kubespider/source_provider/provider.py
+++ b/kubespider/source_provider/provider.py
@@ -9,19 +9,19 @@ class SourceProvider(metaclass=abc.ABCMeta):
     def __init__(self) -> None:
         pass
 
-    # 配置中声明的名字
     @abc.abstractmethod
     def get_provider_name(self) -> str:
+        # name of source provider defined in config
         pass
 
-    # 订阅源类型
     @abc.abstractmethod
     def get_provider_type(self) -> str:
+        # type of provider
         pass
 
-    # 订阅源的监听类型，周期订阅or触发式
     @abc.abstractmethod
     def get_provider_listen_type(self) -> str:
+        # listen type of provider, disposable or periodly
         pass
 
     @abc.abstractmethod

--- a/kubespider/source_provider/youtube_source_provider/provider.py
+++ b/kubespider/source_provider/youtube_source_provider/provider.py
@@ -9,20 +9,28 @@ from api import types
 
 
 class YouTubeSourceProvider(provider.SourceProvider):
-    def __init__(self) -> None:
-        self.provider_type = types.SOURCE_PROVIDER_DISPOSABLE_TYPE
+    def __init__(self, name: str) -> None:
+        self.provider_listen_type = types.SOURCE_PROVIDER_DISPOSABLE_TYPE
         self.link_type = types.LINK_TYPE_GENERAL
         self.webhook_enable = True
-        self.provider_name = 'youtube_source_provider'
+        self.provider_type = 'youtube_source_provider'
+        self.provider_name = name
 
     def get_provider_name(self) -> str:
         return self.provider_name
-
+    
     def get_provider_type(self) -> str:
         return self.provider_type
 
-    def get_download_provider(self) -> str:
+    def get_provider_listen_type(self) -> str:
+        return self.provider_listen_type
+
+    def get_download_provider_type(self) -> str:
         return "yt-dlp"
+    
+    def get_prefer_download_provider(self) -> list:
+        cfg = provider.load_source_provide_config(self.provider_name)
+        return cfg['downloader']
 
     def get_link_type(self) -> str:
         return self.link_type

--- a/kubespider/source_provider/youtube_source_provider/provider.py
+++ b/kubespider/source_provider/youtube_source_provider/provider.py
@@ -18,7 +18,7 @@ class YouTubeSourceProvider(provider.SourceProvider):
 
     def get_provider_name(self) -> str:
         return self.provider_name
-    
+
     def get_provider_type(self) -> str:
         return self.provider_type
 

--- a/kubespider/source_provider/youtube_source_provider/provider.py
+++ b/kubespider/source_provider/youtube_source_provider/provider.py
@@ -27,17 +27,21 @@ class YouTubeSourceProvider(provider.SourceProvider):
 
     def get_download_provider_type(self) -> str:
         return "yt-dlp"
-    
+
+    def get_download_param(self) -> list:
+        cfg = provider.load_source_provide_config(self.provider_name)
+        return cfg.get('download_param')
+
     def get_prefer_download_provider(self) -> list:
         cfg = provider.load_source_provide_config(self.provider_name)
-        return cfg['downloader']
+        return cfg.get('downloader')
 
     def get_link_type(self) -> str:
         return self.link_type
 
     def provider_enabled(self) -> bool:
         cfg = provider.load_source_provide_config(self.provider_name)
-        return cfg['enable']
+        return cfg.get('enable', True)
 
     def is_webhook_enable(self) -> bool:
         return self.webhook_enable


### PR DESCRIPTION
Close #79 

* 支持多个下载器、订阅源，名字可以自由配置，使用`type`指定下载器类型
* 订阅源可以按名字指定使用的下载器
* 订阅源可以自定义下载参数，传递给下载器使用；具体含义将由下载器定义（目前仅qBittorrent支持下载参数）
* 按以上改动更新了一波readme

个人仅有mikan+qb+aria的下载环境，其他配置需要众测一下。