### PR TITLE
fix&feat: 修正mjtt获取下载链接不一定是magent。增强get_link_type获取链接类型。

### DIFF
--- a/kubespider/core/webhook_server.py
+++ b/kubespider/core/webhook_server.py
@@ -1,6 +1,5 @@
 import logging
 import json
-from urllib.parse import urlparse
 
 from flask import Flask,jsonify,request
 
@@ -57,7 +56,7 @@ def download_handler():
 
     err = None
     if match_one_provider is False:
-        link_type = get_link_type(source)
+        link_type = helper.get_link_type(source)
         # If we not match the source provider, just download to common path
         # TODO: implement a better classification if no source provider match
         path = helper.convert_file_type_to_path(types.FILE_TYPE_COMMON) + '/' + path
@@ -92,15 +91,6 @@ def download_links_with_provider(source: str, source_provider: sp.SourceProvider
         if err is not None:
             return err
     return None
-
-def get_link_type(url):
-    if url.startswith('magnet:'):
-        return types.LINK_TYPE_MAGNET
-    if urlparse(url).path.endswith('torrent'):
-        return types.LINK_TYPE_TORRENT
-
-    # TODO: implement other type, like music mv or short video
-    return types.LINK_TYPE_GENERAL
 
 def send_ok_response():
     resp = jsonify('OK')

--- a/kubespider/source_provider/meijutt_source_provider/provider.py
+++ b/kubespider/source_provider/meijutt_source_provider/provider.py
@@ -72,6 +72,9 @@ class MeijuttSourceProvider(provider.SourceProvider):
             links = div[0].find_all('input', ['class', 'down_url'])
             for link in links:
                 url = link.get('value')
+                link_type = helper.get_link_type(url)
+                if link_type != self.link_type:
+                    continue
                 logging.info('meijutt find %s', helper.format_long_string(url))
                 ret.append({'path': tv_link['tv_name'], 'link': url, 'file_type': types.FILE_TYPE_VIDEO_TV})
         return ret

--- a/kubespider/utils/helper.py
+++ b/kubespider/utils/helper.py
@@ -4,6 +4,7 @@ import hashlib
 import logging
 import threading
 from enum import Enum
+from urllib.parse import urlparse
 
 import urllib
 from urllib import request
@@ -93,3 +94,13 @@ def get_request_controller() -> request.OpenerDirector:
     headers = ("User-Agent", "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 Safari/537.36 QIHU 360SE")
     handler.addheaders = [headers]
     return handler
+
+
+def get_link_type(url):
+    if url.startswith('magnet:'):
+        return types.LINK_TYPE_MAGNET
+    if urlparse(url).path.endswith('torrent'):
+        return types.LINK_TYPE_TORRENT
+
+    # TODO: implement other type, like music mv or short video
+    return types.LINK_TYPE_GENERAL


### PR DESCRIPTION
### Fix
- `kubespider/source_provider/meijutt_source_provider/provider.py` 检查mjtt获取的下载链接类型是否符合provider.link_type。

### Feat
- `get_link_type ` 获取链接类型时，增加根据rfc6266从headers中获取filename并检查类型是否为torrent。