### PR TITLE
配置读取改成注入形式

### DIFF
--- a/kubespider/core/kubespider_global.py
+++ b/kubespider/core/kubespider_global.py
@@ -14,6 +14,7 @@ import download_provider.transmission_download_provider.provider as transmission
 
 from utils import helper
 from utils.helper import Config
+from utils.config_reader import YamlFileSectionConfigReader
 
 source_provider_init_func = {
     'bilibili_source_provider': bilibili_source_provider.BilibiliSourceProvider,
@@ -27,7 +28,7 @@ source_provider_init_func = {
 def get_source_provider(provider_name: str, config: dict):
     provider_type = config['type']
     try:
-        return source_provider_init_func[provider_type](provider_name)
+        return source_provider_init_func[provider_type](provider_name, YamlFileSectionConfigReader(Config.SOURCE_PROVIDER.config_path(), provider_name))
     except Exception as exc:
         raise Exception(str('unknown source provider type %s', provider_type)) from exc
 
@@ -49,7 +50,7 @@ downloader_provider_init_func = {
 def get_download_provider(provider_name: str, config: dict):
     provider_type = config['type']
     try:
-        return downloader_provider_init_func[provider_type](provider_name)
+        return downloader_provider_init_func[provider_type](provider_name, YamlFileSectionConfigReader(Config.DOWNLOAD_PROVIDER.config_path(), provider_name))
     except Exception as exc:
         raise Exception(str('unknown download provider type %s', provider_type)) from exc
 

--- a/kubespider/core/kubespider_global.py
+++ b/kubespider/core/kubespider_global.py
@@ -14,7 +14,7 @@ import download_provider.transmission_download_provider.provider as transmission
 
 from utils import helper
 from utils.helper import Config
-from utils.config_reader import YamlFileSectionConfigReader
+from utils.config_reader import YamlFileSectionConfigReader, YamlFileConfigReader
 
 source_provider_init_func = {
     'bilibili_source_provider': bilibili_source_provider.BilibiliSourceProvider,
@@ -34,7 +34,7 @@ def get_source_provider(provider_name: str, config: dict):
 
 source_providers = []
 
-source_config = helper.load_config(Config.SOURCE_PROVIDER)
+source_config = YamlFileConfigReader(Config.SOURCE_PROVIDER.config_path()).read()
 for name in source_config:
     source_providers.append(get_source_provider(name, source_config[name]))
 
@@ -57,7 +57,7 @@ def get_download_provider(provider_name: str, config: dict):
 
 download_providers = []
 
-download_config = helper.load_config(Config.DOWNLOAD_PROVIDER)
+download_config = YamlFileConfigReader(Config.DOWNLOAD_PROVIDER.config_path()).read()
 for name in download_config:
     download_providers.append(get_download_provider(name, download_config[name]))
 

--- a/kubespider/core/kubespider_global.py
+++ b/kubespider/core/kubespider_global.py
@@ -12,7 +12,6 @@ import download_provider.youget_download_provider.provider as youget_download_pr
 import download_provider.ytdlp_download_provider.provider as ytdlp_download_provider
 import download_provider.transmission_download_provider.provider as transmission_download_provider
 
-from utils import helper
 from utils.helper import Config
 from utils.config_reader import YamlFileSectionConfigReader, YamlFileConfigReader
 

--- a/kubespider/core/period_server.py
+++ b/kubespider/core/period_server.py
@@ -6,10 +6,12 @@ from api import types
 from core import download_trigger
 from utils import helper
 from utils.helper import Config
+from utils.config_reader import YamlFileConfigReader
 import source_provider.provider as sp
 
 class PeriodServer:
     def __init__(self, source_providers, download_providers) -> None:
+        self.state_config = YamlFileConfigReader(Config.STATE.config_path())
         self.period_seconds = 3600
         self.source_providers = source_providers
         self.download_providers = download_providers
@@ -68,14 +70,9 @@ class PeriodServer:
         return err
 
     def load_state(self, provider_name) -> list:
-        all_state = helper.load_config(Config.STATE)
-        if provider_name not in all_state.keys():
-            return []
-        return all_state[provider_name]
+        return self.state_config.read().get(provider_name, [])
 
     def save_state(self, provider_name, state) -> None:
-        all_state = helper.load_config(Config.STATE)
-        all_state[provider_name] = state
-        helper.dump_config(Config.STATE, all_state)
+        self.state_config.parcial_update(lambda all_state: all_state.update({provider_name: state}))
 
 kubespider_period_server = PeriodServer(None, None)

--- a/kubespider/download_provider/aria2_download_provider/provider.py
+++ b/kubespider/download_provider/aria2_download_provider/provider.py
@@ -3,12 +3,14 @@ import os
 
 import aria2p
 
+from utils.config_reader import AbsConfigReader
 from download_provider import provider
 from api import types
 
 
 class Aria2DownloadProvider(provider.DownloadProvider):
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, config_reader: AbsConfigReader) -> None:
+        super().__init__(name, config_reader)
         self.provider_name = name
         self.provider_type = 'aria2_download_provider'
         self.rpc_endpoint_host = ''
@@ -24,12 +26,10 @@ class Aria2DownloadProvider(provider.DownloadProvider):
         return self.provider_type
 
     def provider_enabled(self) -> bool:
-        cfg = provider.load_download_provider_config(self.provider_name)
-        return cfg['enable']
+        return self.config_reader.read()['enable']
 
     def provide_priority(self) -> int:
-        cfg = provider.load_download_provider_config(self.provider_name)
-        return cfg['priority']
+        return self.config_reader.read()['priority']
 
     def get_defective_task(self) -> dict:
         defective_tasks = []
@@ -94,7 +94,7 @@ class Aria2DownloadProvider(provider.DownloadProvider):
             return err
 
     def load_config(self) -> TypeError:
-        cfg = provider.load_download_provider_config(self.provider_name)
+        cfg = self.config_reader.read()
         self.rpc_endpoint_host = cfg['rpc_endpoint_host']
         self.rpc_endpoint_port = cfg['rpc_endpoint_port']
         self.download_base_path = cfg['download_base_path']

--- a/kubespider/download_provider/provider.py
+++ b/kubespider/download_provider/provider.py
@@ -1,15 +1,11 @@
 import abc
 
 from utils.config_reader import AbsConfigReader
-from utils import helper
-from utils.helper import Config
-
 
 class DownloadProvider(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def __init__(self, name: str, config_reader: AbsConfigReader) -> None:
         self.config_reader = config_reader
-        pass
 
     @abc.abstractmethod
     def get_provider_name(self) -> str:

--- a/kubespider/download_provider/provider.py
+++ b/kubespider/download_provider/provider.py
@@ -1,12 +1,14 @@
 import abc
 
+from utils.config_reader import AbsConfigReader
 from utils import helper
 from utils.helper import Config
 
 
 class DownloadProvider(metaclass=abc.ABCMeta):
     @abc.abstractmethod
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, config_reader: AbsConfigReader) -> None:
+        self.config_reader = config_reader
         pass
 
     @abc.abstractmethod
@@ -49,8 +51,3 @@ class DownloadProvider(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def load_config(self) -> TypeError:
         pass
-
-
-def load_download_provider_config(provider_name: str) -> dict:
-    cfg = helper.load_config(Config.DOWNLOAD_PROVIDER)
-    return cfg[provider_name]

--- a/kubespider/download_provider/qbittorrent_download_provider/provider.py
+++ b/kubespider/download_provider/qbittorrent_download_provider/provider.py
@@ -2,6 +2,7 @@ import logging
 import os
 
 import qbittorrentapi
+from utils.config_reader import AbsConfigReader
 from qbittorrentapi.definitions import TorrentStates
 
 from download_provider import provider
@@ -11,7 +12,8 @@ from api import types
 class QbittorrentDownloadProvider(
         provider.DownloadProvider # pylint length
     ):
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, config_reader: AbsConfigReader) -> None:
+        super().__init__(name, config_reader)
         self.provider_name = name
         self.provider_type = 'qbittorrent_download_provider'
         self.http_endpoint_host = ''
@@ -31,12 +33,10 @@ class QbittorrentDownloadProvider(
         return self.provider_type
 
     def provider_enabled(self) -> bool:
-        cfg = provider.load_download_provider_config(self.provider_name)
-        return cfg['enable']
+        return self.config_reader.read()['enable']
 
     def provide_priority(self) -> int:
-        cfg = provider.load_download_provider_config(self.provider_name)
-        return cfg['priority']
+        return self.config_reader.read()['priority']
 
     def get_defective_task(self) -> dict:
         torrents_info = self.client.torrents_info()
@@ -110,7 +110,7 @@ class QbittorrentDownloadProvider(
 
 
     def load_config(self) -> TypeError:
-        cfg = provider.load_download_provider_config(self.provider_name)
+        cfg = self.config_reader.read()
         self.http_endpoint_host = cfg['http_endpoint_host']
         self.http_endpoint_port = cfg['http_endpoint_port']
         self.download_base_path = cfg['download_base_path']

--- a/kubespider/download_provider/transmission_download_provider/provider.py
+++ b/kubespider/download_provider/transmission_download_provider/provider.py
@@ -1,6 +1,7 @@
 import logging
 import os
 
+from utils.config_reader import AbsConfigReader
 from urllib.parse import urlparse
 from download_provider import provider
 from transmission_rpc import Client
@@ -9,7 +10,8 @@ from transmission_rpc import Client
 class TransmissionProvider(
     provider.DownloadProvider  # pylint length
 ):
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, config_reader: AbsConfigReader) -> None:
+        super().__init__(name, config_reader)
         self.provider_name = name
         self.provider_type = 'transmission_download_provider'
         self.client = None
@@ -22,12 +24,10 @@ class TransmissionProvider(
         return self.provider_type
 
     def provider_enabled(self) -> bool:
-        cfg = provider.load_download_provider_config(self.provider_name)
-        return cfg['enable']
+        return self.config_reader.read()['enable']
 
     def provide_priority(self) -> int:
-        cfg = provider.load_download_provider_config(self.provider_name)
-        return cfg['priority']
+        return self.config_reader.read()['priority']
 
     def get_defective_task(self) -> dict:
         # Note: The definition of transmission state does not match this method, returning an empty list temporarily.
@@ -67,7 +67,7 @@ class TransmissionProvider(
         return TypeError('Transmission not support general task download')
 
     def load_config(self) -> TypeError:
-        cfg = provider.load_download_provider_config(self.provider_name)
+        cfg = self.config_reader.read()
         self.download_base_path = cfg['download_base_path']
         http_endpoint = cfg['http_endpoint']
         username = cfg['username']

--- a/kubespider/download_provider/transmission_download_provider/provider.py
+++ b/kubespider/download_provider/transmission_download_provider/provider.py
@@ -1,8 +1,8 @@
 import logging
 import os
 
-from utils.config_reader import AbsConfigReader
 from urllib.parse import urlparse
+from utils.config_reader import AbsConfigReader
 from download_provider import provider
 from transmission_rpc import Client
 

--- a/kubespider/download_provider/xunlei_download_provider/provider.py
+++ b/kubespider/download_provider/xunlei_download_provider/provider.py
@@ -8,11 +8,13 @@ import requests
 import execjs
 import libtorrent as lb
 
+from utils.config_reader import AbsConfigReader
 from download_provider import provider
 
 
 class XunleiDownloadProvider(provider.DownloadProvider):
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, config_reader: AbsConfigReader) -> None:
+        super().__init__(name, config_reader)
         self.provider_name = name
         self.provider_type = 'xunlei_download_provider'
         self.http_endpoint = ''
@@ -26,12 +28,10 @@ class XunleiDownloadProvider(provider.DownloadProvider):
         return self.provider_type
 
     def provider_enabled(self) -> bool:
-        cfg = provider.load_download_provider_config(self.provider_name)
-        return cfg['enable']
+        return self.config_reader.read()['enable']
 
     def provide_priority(self) -> int:
-        cfg = provider.load_download_provider_config(self.provider_name)
-        return cfg['priority']
+        return self.config_reader.read()['priority']
 
     def get_defective_task(self) -> dict:
         # if xunlei doesn't work, it means other tools couldn't, so just ignore it.
@@ -63,7 +63,7 @@ class XunleiDownloadProvider(provider.DownloadProvider):
         return self.send_task(token, file_info, url, path)
 
     def load_config(self) -> TypeError:
-        cfg = provider.load_download_provider_config(self.provider_name)
+        cfg = self.config_reader.read()
         self.http_endpoint = cfg['http_endpoint']
         token_js_path = cfg['token_js_path']
         with open(token_js_path, 'r', encoding='utf-8') as js_file:

--- a/kubespider/download_provider/youget_download_provider/provider.py
+++ b/kubespider/download_provider/youget_download_provider/provider.py
@@ -3,13 +3,15 @@ import json
 
 import requests
 
+from utils.config_reader import AbsConfigReader
 from download_provider import provider
 
 
 class YougetDownloadProvider(
         provider.DownloadProvider # pylint length
     ):
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, config_reader: AbsConfigReader) -> None:
+        super().__init__(name, config_reader)
         self.provider_name = name
         self.provider_type = 'youget_download_provider'
         self.http_endpoint_host = ''
@@ -22,12 +24,10 @@ class YougetDownloadProvider(
         return self.provider_type
 
     def provider_enabled(self) -> bool:
-        cfg = provider.load_download_provider_config(self.provider_name)
-        return cfg['enable']
+        return self.config_reader.read()['enable']
 
     def provide_priority(self) -> int:
-        cfg = provider.load_download_provider_config(self.provider_name)
-        return cfg['priority']
+        return self.config_reader.read()['priority']
 
     def get_defective_task(self) -> dict:
         # These tasks is special, other download software could not handle
@@ -60,6 +60,6 @@ class YougetDownloadProvider(
         return None
 
     def load_config(self) -> TypeError:
-        cfg = provider.load_download_provider_config(self.provider_name)
+        cfg = self.config_reader.read()
         self.http_endpoint_host = cfg['http_endpoint_host']
         self.http_endpoint_port = cfg['http_endpoint_port']

--- a/kubespider/download_provider/ytdlp_download_provider/provider.py
+++ b/kubespider/download_provider/ytdlp_download_provider/provider.py
@@ -3,13 +3,15 @@ import json
 
 import requests
 
+from utils.config_reader import AbsConfigReader
 from download_provider import provider
 
 
 class YTDlpDownloadProvider(
         provider.DownloadProvider # pylint length
     ):
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, config_reader: AbsConfigReader) -> None:
+        super().__init__(name, config_reader)
         self.provider_name = name
         self.provider_type = 'ytdlp_download_provider'
         self.http_endpoint_host = ''
@@ -22,12 +24,10 @@ class YTDlpDownloadProvider(
         return self.provider_type
 
     def provider_enabled(self) -> bool:
-        cfg = provider.load_download_provider_config(self.provider_name)
-        return cfg['enable']
+        return self.config_reader.read()['enable']
 
     def provide_priority(self) -> int:
-        cfg = provider.load_download_provider_config(self.provider_name)
-        return cfg['priority']
+        return self.config_reader.read()['priority']
 
     def get_defective_task(self) -> dict:
         # These tasks is special, other download software could not handle
@@ -60,6 +60,6 @@ class YTDlpDownloadProvider(
         return None
 
     def load_config(self) -> TypeError:
-        cfg = provider.load_download_provider_config(self.provider_name)
+        cfg = self.config_reader.read()
         self.http_endpoint_host = cfg['http_endpoint_host']
         self.http_endpoint_port = cfg['http_endpoint_port']

--- a/kubespider/source_provider/bilibili_source_provider/provider.py
+++ b/kubespider/source_provider/bilibili_source_provider/provider.py
@@ -6,10 +6,12 @@ from urllib.parse import urlparse
 
 from source_provider import provider
 from api import types
+from utils.config_reader import AbsConfigReader
 
 
 class BilibiliSourceProvider(provider.SourceProvider):
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, config_reader: AbsConfigReader) -> None:
+        super().__init__(config_reader)
         self.provider_listen_type = types.SOURCE_PROVIDER_DISPOSABLE_TYPE
         self.link_type = types.LINK_TYPE_GENERAL
         self.webhook_enable = True
@@ -29,19 +31,16 @@ class BilibiliSourceProvider(provider.SourceProvider):
         return "youget_download_provider"
 
     def get_prefer_download_provider(self) -> list:
-        cfg = provider.load_source_provide_config(self.provider_name)
-        return cfg.get('downloader')
+        return self.config_reader.read().get('downloader')
 
     def get_download_param(self) -> list:
-        cfg = provider.load_source_provide_config(self.provider_name)
-        return cfg.get('download_param')
+        return self.config_reader.read().get('download_param')
 
     def get_link_type(self) -> str:
         return self.link_type
 
     def provider_enabled(self) -> bool:
-        cfg = provider.load_source_provide_config(self.provider_name)
-        return cfg.get('enable', True)
+        return self.config_reader.read().get('enable', True)
 
     def is_webhook_enable(self) -> bool:
         return self.webhook_enable

--- a/kubespider/source_provider/btbtt12_disposable_source_provider/provider.py
+++ b/kubespider/source_provider/btbtt12_disposable_source_provider/provider.py
@@ -9,10 +9,12 @@ from bs4 import BeautifulSoup
 
 from source_provider import provider
 from api import types
+from utils.config_reader import AbsConfigReader
 
 
 class Btbtt12DisposableSourceProvider(provider.SourceProvider):
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, config_reader: AbsConfigReader) -> None:
+        super().__init__(config_reader)
         self.provider_listen_type = types.SOURCE_PROVIDER_DISPOSABLE_TYPE
         self.link_type = types.LINK_TYPE_TORRENT
         self.webhook_enable = True
@@ -32,19 +34,16 @@ class Btbtt12DisposableSourceProvider(provider.SourceProvider):
         return None
 
     def get_prefer_download_provider(self) -> list:
-        cfg = provider.load_source_provide_config(self.provider_name)
-        return cfg.get('downloader')
+        return self.config_reader.read().get('downloader')
 
     def get_download_param(self) -> list:
-        cfg = provider.load_source_provide_config(self.provider_name)
-        return cfg.get('download_param')
+        return self.config_reader.read().get('download_param')
 
     def get_link_type(self) -> str:
         return self.link_type
 
     def provider_enabled(self) -> bool:
-        cfg = provider.load_source_provide_config(self.provider_name)
-        return cfg.get('enable', True)
+        return self.config_reader.read().get('enable', True)
 
     def is_webhook_enable(self) -> bool:
         return self.webhook_enable

--- a/kubespider/source_provider/general_rss_source_provider/provider.py
+++ b/kubespider/source_provider/general_rss_source_provider/provider.py
@@ -11,12 +11,13 @@ import logging
 import feedparser
 from api import types
 from source_provider import provider
+from utils.config_reader import AbsConfigReader
 
 class GeneralRssSourceProvider(provider.SourceProvider):
     """
     Description: general rss source provider
     """
-    def __init__(self, name) -> None:
+    def __init__(self, name: str, config_reader: AbsConfigReader) -> None:
         """
         Description: init class of GeneralRssSourceProvider
                     provider_type: general_rss_source_provider
@@ -34,6 +35,7 @@ class GeneralRssSourceProvider(provider.SourceProvider):
         Args:
             rss_config: config member of rss config, file is ./config/general_rss.json
         """
+        super().__init__(config_reader)
         self.rss_name = None
         self.rss_link = None
         self.webhook_enable = False
@@ -79,8 +81,7 @@ class GeneralRssSourceProvider(provider.SourceProvider):
         return self.provider_listen_type
 
     def provider_enabled(self) -> bool:
-        cfg = provider.load_source_provide_config(self.provider_name)
-        return cfg.get('enable', True)
+        return self.config_reader.read().get('enable', True)
 
     def is_webhook_enable(self) -> bool:
         return self.webhook_enable
@@ -121,7 +122,7 @@ class GeneralRssSourceProvider(provider.SourceProvider):
         pass
 
     def load_config(self) -> None:
-        cfg = provider.load_source_provide_config(self.provider_name)
+        cfg = self.config_reader.read()
         self.rss_name = cfg.get("rss_name")
         self.rss_link = cfg.get("rss_link")
         self.rss_tpye = cfg.get("rss_type")

--- a/kubespider/source_provider/mikanani_source_provider/provider.py
+++ b/kubespider/source_provider/mikanani_source_provider/provider.py
@@ -11,10 +11,12 @@ from bs4 import BeautifulSoup
 from source_provider import provider
 from api import types
 from utils import helper
+from utils.config_reader import AbsConfigReader
 
 
 class MikananiSourceProvider(provider.SourceProvider):
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, config_reader: AbsConfigReader) -> None:
+        super().__init__(config_reader)
         self.provider_listen_type = types.SOURCE_PROVIDER_PERIOD_TYPE
         self.link_type = types.LINK_TYPE_TORRENT
         self.webhook_enable = False
@@ -36,19 +38,16 @@ class MikananiSourceProvider(provider.SourceProvider):
         return None
 
     def get_prefer_download_provider(self) -> list:
-        cfg = provider.load_source_provide_config(self.provider_name)
-        return cfg.get('downloader')
+        return self.config_reader.read().get('downloader')
 
     def get_download_param(self) -> list:
-        cfg = provider.load_source_provide_config(self.provider_name)
-        return cfg.get('download_param')
+        return self.config_reader.read().get('download_param')
 
     def get_link_type(self) -> str:
         return self.link_type
 
     def provider_enabled(self) -> bool:
-        cfg = provider.load_source_provide_config(self.provider_name)
-        return cfg.get('enable', True)
+        return self.config_reader.read().get('enable', True)
 
     def is_webhook_enable(self) -> bool:
         return self.webhook_enable
@@ -95,8 +94,7 @@ class MikananiSourceProvider(provider.SourceProvider):
             return []
 
     def load_filter_config(self) -> str:
-        cfg = provider.load_source_provide_config(self.provider_name)
-        return cfg.get('filter')
+        return self.config_reader.read().get('filter')
 
     def get_anime_path(self, element) -> str:
         # get the path of anime source, or None for invalid item
@@ -118,7 +116,7 @@ class MikananiSourceProvider(provider.SourceProvider):
         pass
 
     def load_config(self) -> None:
-        cfg = provider.load_source_provide_config(self.provider_name)
+        cfg = self.config_reader.read()
         logging.info('mikanani rss link is:%s', cfg['rss_link'])
         self.rss_link = cfg['rss_link']
 

--- a/kubespider/source_provider/provider.py
+++ b/kubespider/source_provider/provider.py
@@ -2,11 +2,13 @@ import abc
 
 from utils import helper
 from utils.helper import Config
+from utils.config_reader import AbsConfigReader
 
 
 class SourceProvider(metaclass=abc.ABCMeta):
     @abc.abstractmethod
-    def __init__(self) -> None:
+    def __init__(self, config_reader: AbsConfigReader) -> None:
+        self.config_reader = config_reader
         pass
 
     @abc.abstractmethod
@@ -70,13 +72,3 @@ class SourceProvider(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def load_config(self) -> None:
         pass
-
-
-def load_source_provide_config(provider_name) -> dict:
-    cfg = helper.load_config(Config.SOURCE_PROVIDER)
-    return cfg[provider_name]
-
-def save_source_provider_config(provider_name, provider_cfg) -> dict:
-    cfg = helper.load_config(Config.SOURCE_PROVIDER)
-    cfg[provider_name] = provider_cfg
-    helper.dump_config(Config.SOURCE_PROVIDER, cfg)

--- a/kubespider/source_provider/provider.py
+++ b/kubespider/source_provider/provider.py
@@ -1,7 +1,5 @@
 import abc
 
-from utils import helper
-from utils.helper import Config
 from utils.config_reader import AbsConfigReader
 
 
@@ -9,7 +7,6 @@ class SourceProvider(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def __init__(self, config_reader: AbsConfigReader) -> None:
         self.config_reader = config_reader
-        pass
 
     @abc.abstractmethod
     def get_provider_name(self) -> str:

--- a/kubespider/source_provider/youtube_source_provider/provider.py
+++ b/kubespider/source_provider/youtube_source_provider/provider.py
@@ -6,10 +6,12 @@ from urllib.parse import urlparse
 
 from source_provider import provider
 from api import types
+from utils.config_reader import AbsConfigReader
 
 
 class YouTubeSourceProvider(provider.SourceProvider):
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, config_reader: AbsConfigReader) -> None:
+        super().__init__(config_reader)
         self.provider_listen_type = types.SOURCE_PROVIDER_DISPOSABLE_TYPE
         self.link_type = types.LINK_TYPE_GENERAL
         self.webhook_enable = True
@@ -29,19 +31,16 @@ class YouTubeSourceProvider(provider.SourceProvider):
         return "ytdlp_download_provider"
 
     def get_download_param(self) -> list:
-        cfg = provider.load_source_provide_config(self.provider_name)
-        return cfg.get('download_param')
+        return self.config_reader.read().get('download_param')
 
     def get_prefer_download_provider(self) -> list:
-        cfg = provider.load_source_provide_config(self.provider_name)
-        return cfg.get('downloader')
+        return self.config_reader.read().get('downloader')
 
     def get_link_type(self) -> str:
         return self.link_type
 
     def provider_enabled(self) -> bool:
-        cfg = provider.load_source_provide_config(self.provider_name)
-        return cfg.get('enable', True)
+        return self.config_reader.read().get('enable', True)
 
     def is_webhook_enable(self) -> bool:
         return self.webhook_enable

--- a/kubespider/test/source_provider/test_mikanani_source_provider.py
+++ b/kubespider/test/source_provider/test_mikanani_source_provider.py
@@ -21,7 +21,7 @@ class MikkananiSouirceProviderTest(unittest.TestCase):
         with open(self.test_file, encoding="utf-8", mode= 'r') as test_file:
             lines = test_file.readlines()
         return list(filter(lambda p: p is not None, map(lambda p: self.provider.check_anime_title(p, pattern), lines)))
-    
+
     def test_read_config(self):
         downloader = self.provider.get_prefer_download_provider()
         self.assertEqual(downloader, 'test_downloader')
@@ -43,7 +43,7 @@ class MikkananiSouirceProviderTest(unittest.TestCase):
 class MemDictConfigReader(AbsConfigReader):
     def __init__(self,config: dict) -> None:
         self.config = config
-    
+
     def save(self, new_data: dict):
         self.config = new_data
 

--- a/kubespider/test/source_provider/test_mikanani_source_provider.py
+++ b/kubespider/test/source_provider/test_mikanani_source_provider.py
@@ -3,11 +3,13 @@ import logging
 import re
 
 from source_provider.mikanani_source_provider.provider import MikananiSourceProvider
+from utils.config_reader import AbsConfigReader
 
-logging.basicConfig(level=logging.DEBUG, format='%(asctime)s-%(levelname)s: %(message)s')
+logging.basicConfig(level=logging.ERROR, format='%(asctime)s-%(levelname)s: %(message)s')
 class MikkananiSouirceProviderTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.provider = MikananiSourceProvider("test")
+        reader = MemDictConfigReader({'download_param': {'tags': ["test"]}, 'downloader': 'test_downloader'})
+        self.provider = MikananiSourceProvider("test", reader)
         # 一共7个记录
         self.test_file = "./test/source_provider/test_source.txt"
 
@@ -19,6 +21,12 @@ class MikkananiSouirceProviderTest(unittest.TestCase):
         with open(self.test_file, encoding="utf-8", mode= 'r') as test_file:
             lines = test_file.readlines()
         return list(filter(lambda p: p is not None, map(lambda p: self.provider.check_anime_title(p, pattern), lines)))
+    
+    def test_read_config(self):
+        downloader = self.provider.get_prefer_download_provider()
+        self.assertEqual(downloader, 'test_downloader')
+        param = self.provider.get_download_param()
+        self.assertEqual({'tags': ["test"]}, param)
 
     def test_title_filter_full(self):
         title_dict = self.load(None)
@@ -31,3 +39,13 @@ class MikkananiSouirceProviderTest(unittest.TestCase):
     def test_title_filter_reg_except(self):
         title_dict = self.load( "^((?!繁).)*$")
         self.assertEqual(4, len(title_dict))
+
+class MemDictConfigReader(AbsConfigReader):
+    def __init__(self,config: dict) -> None:
+        self.config = config
+    
+    def save(self, new_data: dict):
+        self.config = new_data
+
+    def read(self) -> dict:
+        return self.config

--- a/kubespider/test/utils/test_config.yaml
+++ b/kubespider/test/utils/test_config.yaml
@@ -1,0 +1,7 @@
+section_one:
+  version: 1
+
+section_two:
+  version: 1
+
+outer_key: outer_value

--- a/kubespider/test/utils/test_config_reader.py
+++ b/kubespider/test/utils/test_config_reader.py
@@ -9,12 +9,23 @@ class TestConfigReader(unittest.TestCase):
         self.test_file = "./test/utils/test_config.yaml"
         with open(self.test_file, mode="r") as f:
             self.default_content = f.read()
+        os.mkdir("./test/tmp")
 
     def tearDown(self) -> None:
         # delete the test file
         with open(self.test_file, mode="w") as f:
             f.write(self.default_content)
+        self.remove_files_and_dirs("./test/tmp")
         return super().tearDown()
+
+    def remove_files_and_dirs(self, path):
+        for root, dirs, files in os.walk(path, topdown=False):
+          for file in files:
+              os.remove(os.path.join(root, file))
+          for dir in dirs:
+              os.rmdir(os.path.join(root, dir))
+        os.rmdir(path)
+
     
     def test_yaml_file_reader(self):
         reader = YamlFileConfigReader(self.test_file)
@@ -41,3 +52,11 @@ class TestConfigReader(unittest.TestCase):
         reader_two_data = reader_two.read()
         self.assertEqual(reader_one_data, {"version": 2})
         self.assertEqual(reader_two_data, {"version": 3})
+
+    def test_load_from_non_exist_file(self):
+        # it is ok to load config from file not existing
+        reader = YamlFileConfigReader("./test/tmp/test.yaml")
+        data = reader.read()
+        self.assertEqual(data, {})
+        reader.parcial_update(lambda data: data.update({"version": 1}))
+        self.assertEqual(reader.read(), {"version": 1})

--- a/kubespider/test/utils/test_config_reader.py
+++ b/kubespider/test/utils/test_config_reader.py
@@ -1,5 +1,4 @@
 import unittest
-import yaml
 import os
 from utils.config_reader import YamlFileConfigReader, YamlFileSectionConfigReader
 
@@ -7,26 +6,25 @@ class TestConfigReader(unittest.TestCase):
     def setUp(self):
         # create a simple yaml file for test
         self.test_file = "./test/utils/test_config.yaml"
-        with open(self.test_file, mode="r") as f:
-            self.default_content = f.read()
+        with open(self.test_file, mode="r", encoding="utf-8") as file:
+            self.default_content = file.read()
         os.mkdir("./test/tmp")
 
     def tearDown(self) -> None:
         # delete the test file
-        with open(self.test_file, mode="w") as f:
-            f.write(self.default_content)
+        with open(self.test_file, mode="w", encoding="utf-8") as file:
+            file.write(self.default_content)
         self.remove_files_and_dirs("./test/tmp")
         return super().tearDown()
 
     def remove_files_and_dirs(self, path):
         for root, dirs, files in os.walk(path, topdown=False):
-          for file in files:
-              os.remove(os.path.join(root, file))
-          for dir in dirs:
-              os.rmdir(os.path.join(root, dir))
+            for file in files:
+                os.remove(os.path.join(root, file))
+            for sub_dir in dirs:
+                os.rmdir(os.path.join(root, sub_dir))
         os.rmdir(path)
 
-    
     def test_yaml_file_reader(self):
         reader = YamlFileConfigReader(self.test_file)
         data = reader.read()

--- a/kubespider/test/utils/test_config_reader.py
+++ b/kubespider/test/utils/test_config_reader.py
@@ -1,0 +1,43 @@
+import unittest
+import yaml
+import os
+from utils.config_reader import YamlFileConfigReader, YamlFileSectionConfigReader
+
+class TestConfigReader(unittest.TestCase):
+    def setUp(self):
+        # create a simple yaml file for test
+        self.test_file = "./test/utils/test_config.yaml"
+        with open(self.test_file, mode="r") as f:
+            self.default_content = f.read()
+
+    def tearDown(self) -> None:
+        # delete the test file
+        with open(self.test_file, mode="w") as f:
+            f.write(self.default_content)
+        return super().tearDown()
+    
+    def test_yaml_file_reader(self):
+        reader = YamlFileConfigReader(self.test_file)
+        data = reader.read()
+        data["outer_key"] = "new_value"
+        data["new_key"] = "a"
+        reader.save(data)
+        data = reader.read()
+        self.assertEqual(data["new_key"], "a")
+        self.assertEqual(data["outer_key"], "new_value")
+
+    def test_yaml_section_reader(self):
+        reader_one = YamlFileSectionConfigReader(self.test_file, "section_one")
+        reader_one_data = reader_one.read()
+        reader_two = YamlFileSectionConfigReader(self.test_file, "section_two")
+        reader_two_data = reader_two.read()
+        self.assertEqual(reader_one_data, {"version": 1})
+        self.assertEqual(reader_two_data, {"version": 1})
+        reader_one_data["version"] = 2
+        reader_two_data["version"] = 3
+        reader_one.save(reader_one_data)
+        reader_two.save(reader_two_data)
+        reader_one_data = reader_one.read()
+        reader_two_data = reader_two.read()
+        self.assertEqual(reader_one_data, {"version": 2})
+        self.assertEqual(reader_two_data, {"version": 3})

--- a/kubespider/utils/config_reader.py
+++ b/kubespider/utils/config_reader.py
@@ -1,5 +1,7 @@
 import threading
 import yaml
+import os
+import os
 from abc import ABC, abstractmethod
 
 class AbsConfigReader(ABC):
@@ -23,10 +25,20 @@ class AbsConfigReader(ABC):
         pass
 
 class FileConfigReader(AbsConfigReader):
+    """
+    Basic definition of file config loader
+    """
+    """
+    Basic definition of file config loader
+    """
     def __init__(self, file_path: str):
         self.file_path = file_path
 
     def read_file(self) -> str:
+        if not os.path.exists(self.file_path):
+            return ''
+        if not os.path.exists(self.file_path):
+            return ''
         with open(self.file_path, 'r', encoding='utf-8') as f:
             return f.read()
         
@@ -38,7 +50,11 @@ file_locks = {}
 
 class YamlFileConfigReader(FileConfigReader):
     """
+    A config reader that reads from a single yaml file, 
+    or create one on first save call if not exists
     A config reader that reads from a single yaml file
+    A config reader that reads from a single yaml file, 
+    or create one on first save call if not exists
     """
     def __init__(self, file_path: str):
         super().__init__(file_path)
@@ -48,7 +64,10 @@ class YamlFileConfigReader(FileConfigReader):
     def read(self) -> dict:
         self.file_lock.acquire()
         try:
-            return self.read_data_from_file()
+            conf = self.read_data_from_file()
+            if conf == None:
+                conf = {}
+            return conf
         finally:
             self.file_lock.release()
 
@@ -69,7 +88,10 @@ class YamlFileConfigReader(FileConfigReader):
             self.file_lock.release()
     
     def read_data_from_file(self)-> dict:
-        return yaml.safe_load(self.read_file())
+        conf = yaml.safe_load(self.read_file())
+        if conf == None:
+            conf = {}
+        return conf
     
     def write_data_to_file(self, data: dict):
         self.write_file(yaml.dump(data))

--- a/kubespider/utils/config_reader.py
+++ b/kubespider/utils/config_reader.py
@@ -1,8 +1,8 @@
 import threading
-import yaml
-import os
 import os
 from abc import ABC, abstractmethod
+
+import yaml
 
 class AbsConfigReader(ABC):
     """
@@ -15,19 +15,14 @@ class AbsConfigReader(ABC):
         Reads config from s specific store, like file or memory dict
         Each call of this function will read the latest data from the store
         """
-        pass
 
     @abstractmethod
     def save(self, new_data: dict):
         """
         Saves new data to the store
         """
-        pass
 
 class FileConfigReader(AbsConfigReader):
-    """
-    Basic definition of file config loader
-    """
     """
     Basic definition of file config loader
     """
@@ -39,12 +34,12 @@ class FileConfigReader(AbsConfigReader):
             return ''
         if not os.path.exists(self.file_path):
             return ''
-        with open(self.file_path, 'r', encoding='utf-8') as f:
-            return f.read()
-        
+        with open(self.file_path, 'r', encoding='utf-8') as file:
+            return file.read()
+
     def write_file(self, data_str: str):
-        with open(self.file_path, 'w', encoding='utf-8') as f:
-            f.write(data_str)
+        with open(self.file_path, 'w', encoding='utf-8') as file:
+            file.write(data_str)
 
 file_locks = {}
 
@@ -64,10 +59,7 @@ class YamlFileConfigReader(FileConfigReader):
     def read(self) -> dict:
         self.file_lock.acquire()
         try:
-            conf = self.read_data_from_file()
-            if conf == None:
-                conf = {}
-            return conf
+            return self.read_data_from_file()
         finally:
             self.file_lock.release()
 
@@ -86,13 +78,13 @@ class YamlFileConfigReader(FileConfigReader):
             self.write_data_to_file(data)
         finally:
             self.file_lock.release()
-    
+
     def read_data_from_file(self)-> dict:
         conf = yaml.safe_load(self.read_file())
-        if conf == None:
+        if conf is None:
             conf = {}
         return conf
-    
+
     def write_data_to_file(self, data: dict):
         self.write_file(yaml.dump(data))
 
@@ -106,6 +98,6 @@ class YamlFileSectionConfigReader(YamlFileConfigReader):
 
     def read(self) -> dict:
         return super().read()[self.section]
-    
+
     def save(self, new_data: dict):
         super().parcial_update(lambda data: data.update({self.section: new_data}))

--- a/kubespider/utils/config_reader.py
+++ b/kubespider/utils/config_reader.py
@@ -32,8 +32,6 @@ class FileConfigReader(AbsConfigReader):
     def read_file(self) -> str:
         if not os.path.exists(self.file_path):
             return ''
-        if not os.path.exists(self.file_path):
-            return ''
         with open(self.file_path, 'r', encoding='utf-8') as file:
             return file.read()
 
@@ -45,9 +43,6 @@ file_locks = {}
 
 class YamlFileConfigReader(FileConfigReader):
     """
-    A config reader that reads from a single yaml file, 
-    or create one on first save call if not exists
-    A config reader that reads from a single yaml file
     A config reader that reads from a single yaml file, 
     or create one on first save call if not exists
     """

--- a/kubespider/utils/config_reader.py
+++ b/kubespider/utils/config_reader.py
@@ -1,0 +1,89 @@
+import threading
+import yaml
+from abc import ABC, abstractmethod
+
+class AbsConfigReader(ABC):
+    """
+    Abstract class for config reader
+    """
+
+    @abstractmethod
+    def read(self) -> dict:
+        """
+        Reads config from s specific store, like file or memory dict
+        Each call of this function will read the latest data from the store
+        """
+        pass
+
+    @abstractmethod
+    def save(self, new_data: dict):
+        """
+        Saves new data to the store
+        """
+        pass
+
+class FileConfigReader(AbsConfigReader):
+    def __init__(self, file_path: str):
+        self.file_path = file_path
+
+    def read_file(self) -> str:
+        with open(self.file_path, 'r', encoding='utf-8') as f:
+            return f.read()
+        
+    def write_file(self, data_str: str):
+        with open(self.file_path, 'w', encoding='utf-8') as f:
+            f.write(data_str)
+
+file_locks = {}
+
+class YamlFileConfigReader(FileConfigReader):
+    """
+    A config reader that reads from a single yaml file
+    """
+    def __init__(self, file_path: str):
+        super().__init__(file_path)
+        self.file_lock = file_locks.get(file_path, threading.Lock())
+        file_locks[file_path] = self.file_lock
+
+    def read(self) -> dict:
+        self.file_lock.acquire()
+        try:
+            return self.read_data_from_file()
+        finally:
+            self.file_lock.release()
+
+    def save(self, new_data: dict):
+        self.file_lock.acquire()
+        try:
+            self.write_data_to_file(new_data)
+        finally:
+            self.file_lock.release()
+
+    def parcial_update(self, update):
+        self.file_lock.acquire()
+        try:
+            data = self.read_data_from_file()
+            update(data)
+            self.write_data_to_file(data)
+        finally:
+            self.file_lock.release()
+    
+    def read_data_from_file(self)-> dict:
+        return yaml.safe_load(self.read_file())
+    
+    def write_data_to_file(self, data: dict):
+        self.write_file(yaml.dump(data))
+
+class YamlFileSectionConfigReader(YamlFileConfigReader):
+    """
+    A config reader that reads from a section of yaml file
+    """
+    def __init__(self, file_path: str, section: str):
+        super().__init__(file_path)
+        self.section = section
+
+    def read(self) -> dict:
+        return super().read()[self.section]
+    
+    def save(self, new_data: dict):
+        super().parcial_update(lambda data: data.update({self.section: new_data}))

--- a/kubespider/utils/helper.py
+++ b/kubespider/utils/helper.py
@@ -21,6 +21,9 @@ class Config(str, Enum):
 
     def __str__(self) -> str:
         return str(self.value)
+    
+    def config_path(self) -> str:
+        return os.path.join(cfg_base_path, self)
 
 locks = { i.value: threading.Lock() for i in Config }
 cfg_base_path = config_path = os.path.join(os.getenv('HOME'), '.config/')

--- a/kubespider/utils/helper.py
+++ b/kubespider/utils/helper.py
@@ -6,6 +6,7 @@ import threading
 import cgi
 from enum import Enum
 from urllib.parse import urlparse
+from utils.config_reader import YamlFileConfigReader
 
 import urllib
 from urllib import request
@@ -46,13 +47,6 @@ def load_config(cfg_type: Config):
     finally:
         lock.release()
 
-def dump_config(cfg_type: Config, cfg):
-    lock = locks.get(cfg_type)
-    lock.acquire()
-    try:
-        dump_yaml_config(os.path.join(cfg_base_path, cfg_type), cfg)
-    finally:
-        lock.release()
 
 def load_yaml_config(cfg_path):
     if not os.path.exists(cfg_path):
@@ -77,8 +71,10 @@ def format_long_string(longstr: str) -> str:
         return longstr[:40] + '...'
     return longstr
 
+global_config = YamlFileConfigReader(Config.KUBESPIDER_CONFIG.config_path())
+
 def get_proxy() -> str:
-    cfg = load_config(Config.KUBESPIDER_CONFIG)
+    cfg = global_config.read()
     if cfg is not None:
         return cfg.get('proxy', None)
     return None

--- a/kubespider/utils/helper.py
+++ b/kubespider/utils/helper.py
@@ -2,13 +2,11 @@ import os
 import uuid
 import hashlib
 import logging
-import threading
 import cgi
 import urllib
 from enum import Enum
 from urllib.parse import urlparse
 from urllib import request
-import yaml
 from utils.config_reader import YamlFileConfigReader
 from api import types
 
@@ -24,7 +22,6 @@ class Config(str, Enum):
     def config_path(self) -> str:
         return os.path.join(cfg_base_path, self)
 
-locks = { i.value: threading.Lock() for i in Config }
 cfg_base_path = config_path = os.path.join(os.getenv('HOME'), '.config/')
 
 def get_tmp_file_name(url):
@@ -36,27 +33,6 @@ def get_tmp_file_name(url):
 
 def get_unique_hash(data):
     return hashlib.md5(data.encode('utf-8')).hexdigest()
-
-def load_config(cfg_type: Config):
-    lock = locks.get(cfg_type)
-    lock.acquire()
-    try:
-        return load_yaml_config(os.path.join(cfg_base_path, cfg_type))
-    finally:
-        lock.release()
-
-
-def load_yaml_config(cfg_path):
-    if not os.path.exists(cfg_path):
-        return {}
-
-    with open(cfg_path, 'r', encoding='utf-8') as config_file:
-        cfg = yaml.safe_load(config_file)
-        return cfg
-
-def dump_yaml_config(cfg_path, cfg):
-    with open(cfg_path, 'w', encoding='utf-8') as config_file:
-        yaml.dump(cfg, config_file, encoding='utf-8')
 
 def convert_file_type_to_path(file_type: str):
     if file_type in types.file_type_to_path.keys():

--- a/kubespider/utils/helper.py
+++ b/kubespider/utils/helper.py
@@ -4,14 +4,12 @@ import hashlib
 import logging
 import threading
 import cgi
+import urllib
 from enum import Enum
 from urllib.parse import urlparse
-from utils.config_reader import YamlFileConfigReader
-
-import urllib
 from urllib import request
 import yaml
-
+from utils.config_reader import YamlFileConfigReader
 from api import types
 
 class Config(str, Enum):
@@ -22,7 +20,7 @@ class Config(str, Enum):
 
     def __str__(self) -> str:
         return str(self.value)
-    
+
     def config_path(self) -> str:
         return os.path.join(cfg_base_path, self)
 


### PR DESCRIPTION
将配置读取的逻辑做了抽象，支持给订阅源、下载器和全局设置项注入不同形式的配置读取方式。

在这个能力之上，以后可以更方便实现配置文件拆分，例如`.config/source_provider`下的所有yaml都可以认作订阅源配置，方便mikan源订阅过滤规则太多进行管理。

注入配置可以让`downloader_provider`、`source_provider`自身的代码更加可测，例如可以使用单元测试验证任何一个配置项的存在与否的表现。

后续能做的事情：进行拆分`downloader_provider`、`source_provider`内部逻辑，例如将`mikanani_provider`中访问网页获取标题、`qbittorrent_provider`中实际与qb交互的代理对象也进行注入，就能完全针对里面的代码逻辑进行单元测试了。

> 能做不代表是我做

> 后面精力问题，我不会花很多时间在这里，考虑一下T了我的权限？