### PR TITLE
fix: wrong file type and link type in general_rss_source_provider

### DIFF
--- a/kubespider/source_provider/general_rss_source_provider/provider.py
+++ b/kubespider/source_provider/general_rss_source_provider/provider.py
@@ -105,8 +105,9 @@ class GeneralRssSourceProvider(provider.SourceProvider):
                     link_type = types.LINK_TYPE_TORRENT
                 links.append({
                     "link": url,
-                    "file_type": link_type,
+                    "file_type": self.file_type,
                     "path": path,
+                    "link_type": link_type
                 })
         return links
 


### PR DESCRIPTION
## Proposed Changes

* 修复general_rss_source_provider中文件类型和链接类型错误的bug

**Release Note**
```release-note

```